### PR TITLE
Add Opus codec support (PT 111)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,12 +20,14 @@ jobs:
         with:
           components: rustfmt, clippy
       - uses: Swatinem/rust-cache@v2
-      - name: Install ALSA dev headers
-        run: sudo apt-get update && sudo apt-get install -y libasound2-dev
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y libasound2-dev libopus-dev
       - name: Format
         run: cargo fmt --check
       - name: Clippy
         run: cargo clippy --all-targets -- -D warnings
+      - name: Clippy (opus-codec feature)
+        run: cargo clippy --features opus-codec --all-targets -- -D warnings
       - name: Clippy (cli feature)
         run: cargo clippy --example sipcli --features cli -- -D warnings
 
@@ -36,10 +38,12 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-      - name: Install ALSA dev headers
-        run: sudo apt-get update && sudo apt-get install -y libasound2-dev
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y libasound2-dev libopus-dev
       - name: Test
         run: cargo test --verbose
+      - name: Test (opus-codec feature)
+        run: cargo test --features opus-codec --verbose
       - name: Test (release)
         run: cargo test --release
 
@@ -51,8 +55,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-      - name: Install ALSA dev headers
-        run: sudo apt-get update && sudo apt-get install -y libasound2-dev
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y libasound2-dev libopus-dev
       - name: Start Asterisk
         run: docker compose -f testutil/docker/docker-compose.yml up -d --wait
       - name: Run integration tests
@@ -71,10 +75,13 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-      - name: Install ALSA dev headers
+      - name: Install system dependencies
         if: runner.os == 'Linux'
-        run: sudo apt-get update && sudo apt-get install -y libasound2-dev
+        run: sudo apt-get update && sudo apt-get install -y libasound2-dev libopus-dev
       - name: Build library
         run: cargo build
+      - name: Build library (opus-codec)
+        if: runner.os == 'Linux'
+        run: cargo build --features opus-codec
       - name: Build sipcli
         run: cargo build --example sipcli --features cli --release

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - name: Install ALSA dev headers
-        run: sudo apt-get update && sudo apt-get install -y libasound2-dev
+        run: sudo apt-get update && sudo apt-get install -y libasound2-dev libopus-dev
       - name: Publish
         run: cargo publish
         env:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -101,6 +101,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "audiopus_sys"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62314a1546a2064e033665d658e88c620a62904be945f8147e6b16c3db9f8651"
+dependencies = [
+ "cmake",
+ "log",
+ "pkg-config",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1010,6 +1021,15 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "opus"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d3809943dff6fbad5f0484449ea26bdb9cb7d8efdf26ed50d3c7f227f69eb5c"
+dependencies = [
+ "audiopus_sys",
+]
 
 [[package]]
 name = "parking_lot"
@@ -2038,6 +2058,7 @@ dependencies = [
  "getrandom 0.2.17",
  "hmac",
  "md5",
+ "opus",
  "parking_lot",
  "ratatui",
  "rustls",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,6 +69,11 @@ optional = true
 version = "0.15"
 optional = true
 
+[dependencies.opus]
+version = "0.3"
+optional = true
+
 [features]
 integration = []
+opus-codec = ["opus"]
 cli = ["ratatui", "crossterm", "clap", "serde", "serde_yaml", "dirs-next", "cpal"]

--- a/src/codec/mod.rs
+++ b/src/codec/mod.rs
@@ -1,4 +1,6 @@
 pub mod g722;
+#[cfg(feature = "opus-codec")]
+pub mod opus_codec;
 pub mod pcma;
 pub mod pcmu;
 
@@ -23,6 +25,8 @@ pub fn new_codec_processor(payload_type: i32, pcm_rate: i32) -> Option<Box<dyn C
         0 => Some(Box::new(pcmu::PcmuProcessor::new())),
         8 => Some(Box::new(pcma::PcmaProcessor::new())),
         9 => Some(Box::new(g722::G722Processor::new(pcm_rate as u32))),
+        #[cfg(feature = "opus-codec")]
+        111 => opus_codec::OpusProcessor::new().map(|p| Box::new(p) as Box<dyn CodecProcessor>),
         _ => None,
     }
 }
@@ -58,6 +62,20 @@ mod tests {
     #[test]
     fn codec_processor_unknown_returns_none() {
         assert!(new_codec_processor(99, 8000).is_none());
+    }
+
+    #[cfg(not(feature = "opus-codec"))]
+    #[test]
+    fn codec_processor_opus_without_feature_returns_none() {
         assert!(new_codec_processor(111, 8000).is_none());
+    }
+
+    #[cfg(feature = "opus-codec")]
+    #[test]
+    fn codec_processor_opus_with_feature_returns_some() {
+        let cp = new_codec_processor(111, 8000).unwrap();
+        assert_eq!(cp.payload_type(), 111);
+        assert_eq!(cp.clock_rate(), 48000);
+        assert_eq!(cp.samples_per_frame(), 960);
     }
 }

--- a/src/codec/opus_codec.rs
+++ b/src/codec/opus_codec.rs
@@ -1,0 +1,166 @@
+// Opus codec implementation (RFC 6716, payload type 111).
+//
+// Uses the `opus` crate (libopus FFI) gated behind the `opus-codec` feature.
+// The encoder/decoder operate at 8kHz mono to match the pipeline's PCM rate,
+// but RTP timestamps use the 48kHz clock per RFC 7587.
+
+use super::CodecProcessor;
+use opus::{Application, Channels, Decoder, Encoder};
+
+const PAYLOAD_TYPE: u8 = 111;
+const CLOCK_RATE: u32 = 48000;
+const PCM_RATE: u32 = 8000;
+const SAMPLES_PER_FRAME: u32 = 960; // 20ms at 48kHz clock
+const MAX_DECODE_SAMPLES: usize = 960; // 120ms at 8kHz — handles up to 60ms Opus frames
+
+pub struct OpusProcessor {
+    enc: Encoder,
+    dec: Decoder,
+}
+
+impl OpusProcessor {
+    pub fn new() -> Option<Self> {
+        let enc = Encoder::new(PCM_RATE, Channels::Mono, Application::Voip).ok()?;
+        let dec = Decoder::new(PCM_RATE, Channels::Mono).ok()?;
+        Some(Self { enc, dec })
+    }
+}
+
+impl CodecProcessor for OpusProcessor {
+    fn decode(&mut self, payload: &[u8]) -> Vec<i16> {
+        let mut out = vec![0i16; MAX_DECODE_SAMPLES];
+        match self.dec.decode(payload, &mut out, false) {
+            Ok(n) => {
+                out.truncate(n);
+                out
+            }
+            Err(e) => {
+                tracing::warn!("opus decode error: {}", e);
+                Vec::new()
+            }
+        }
+    }
+
+    fn encode(&mut self, samples: &[i16]) -> Vec<u8> {
+        match self.enc.encode_vec(samples, 4000) {
+            Ok(data) => data,
+            Err(e) => {
+                tracing::warn!("opus encode error: {}", e);
+                Vec::new()
+            }
+        }
+    }
+
+    fn payload_type(&self) -> u8 {
+        PAYLOAD_TYPE
+    }
+
+    fn clock_rate(&self) -> u32 {
+        CLOCK_RATE
+    }
+
+    /// RTP timestamp increment per frame (48kHz clock per RFC 7587).
+    /// The actual PCM buffer size is PCM_FRAME_SIZE (160 samples at 8kHz).
+    fn samples_per_frame(&self) -> u32 {
+        SAMPLES_PER_FRAME
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const PCM_FRAME_SIZE: usize = 160; // 20ms at 8kHz
+
+    #[test]
+    fn interface() {
+        let p = OpusProcessor::new().unwrap();
+        assert_eq!(p.payload_type(), 111);
+        assert_eq!(p.clock_rate(), 48000);
+        assert_eq!(p.samples_per_frame(), 960);
+    }
+
+    #[test]
+    fn round_trip_silence() {
+        let mut p = OpusProcessor::new().unwrap();
+        let silence = vec![0i16; PCM_FRAME_SIZE];
+        let encoded = p.encode(&silence);
+        assert!(!encoded.is_empty());
+        let decoded = p.decode(&encoded);
+        assert_eq!(decoded.len(), PCM_FRAME_SIZE);
+        // Silence should decode to near-zero values
+        for &s in &decoded {
+            assert!(s.abs() < 100, "expected near-silence, got {}", s);
+        }
+    }
+
+    #[test]
+    fn round_trip_tone() {
+        let mut p = OpusProcessor::new().unwrap();
+        let tone: Vec<i16> = (0..PCM_FRAME_SIZE)
+            .map(|i| {
+                let t = i as f64 / PCM_RATE as f64;
+                (f64::sin(2.0 * std::f64::consts::PI * 440.0 * t) * 16000.0) as i16
+            })
+            .collect();
+        let encoded = p.encode(&tone);
+        assert!(!encoded.is_empty());
+        let decoded = p.decode(&encoded);
+        assert_eq!(decoded.len(), PCM_FRAME_SIZE);
+        // Should have non-trivial energy
+        let energy: i64 = decoded.iter().map(|&s| (s as i64) * (s as i64)).sum();
+        assert!(energy > 0, "decoded tone should have energy");
+    }
+
+    #[test]
+    fn compression() {
+        let mut p = OpusProcessor::new().unwrap();
+        let pcm = vec![0i16; PCM_FRAME_SIZE];
+        let encoded = p.encode(&pcm);
+        // Opus compressed output should be smaller than raw PCM (320 bytes)
+        assert!(
+            encoded.len() < PCM_FRAME_SIZE * 2,
+            "encoded {} bytes >= raw {} bytes",
+            encoded.len(),
+            PCM_FRAME_SIZE * 2
+        );
+    }
+
+    #[test]
+    fn output_size_bounded() {
+        let mut p = OpusProcessor::new().unwrap();
+        let tone: Vec<i16> = (0..PCM_FRAME_SIZE)
+            .map(|i| ((i as f64 * 0.1).sin() * 20000.0) as i16)
+            .collect();
+        let encoded = p.encode(&tone);
+        // Max Opus frame at 8kHz VoIP should be well under 4000 bytes
+        assert!(encoded.len() < 4000);
+        assert!(!encoded.is_empty());
+    }
+
+    #[test]
+    fn stateful_encoding() {
+        let mut p = OpusProcessor::new().unwrap();
+        let pcm = vec![1000i16; PCM_FRAME_SIZE];
+        let first = p.encode(&pcm);
+        let second = p.encode(&pcm);
+        // Opus is stateful — second frame may differ from first
+        // Both should be valid non-empty output
+        assert!(!first.is_empty());
+        assert!(!second.is_empty());
+    }
+
+    #[test]
+    fn multi_frame_round_trip() {
+        let mut p = OpusProcessor::new().unwrap();
+        for i in 0..5 {
+            let pcm: Vec<i16> = (0..PCM_FRAME_SIZE)
+                .map(|j| ((j as f64 + i as f64 * 100.0) * 0.05).sin() as i16 * 10000)
+                .collect();
+            let encoded = p.encode(&pcm);
+            assert!(!encoded.is_empty(), "frame {} encode failed", i);
+            let decoded = p.decode(&encoded);
+            assert_eq!(decoded.len(), PCM_FRAME_SIZE, "frame {} decode size", i);
+        }
+    }
+}

--- a/src/sdp.rs
+++ b/src/sdp.rs
@@ -96,6 +96,14 @@ fn codec_name(pt: i32) -> Option<&'static str> {
     }
 }
 
+fn codec_fmtp(pt: i32) -> Option<&'static str> {
+    match pt {
+        101 => Some("0-16"),
+        111 => Some("minptime=20;useinbandfec=0"),
+        _ => None,
+    }
+}
+
 /// Parses a raw SDP string into a [`Session`].
 pub fn parse(raw: &str) -> crate::error::Result<Session> {
     let mut session = Session {
@@ -169,8 +177,14 @@ pub fn parse(raw: &str) -> crate::error::Result<Session> {
     Ok(session)
 }
 
-/// Creates an SDP offer string.
-pub fn build_offer(ip: &str, port: i32, codecs: &[i32], direction: &str) -> String {
+fn build_offer_inner(
+    ip: &str,
+    port: i32,
+    codecs: &[i32],
+    direction: &str,
+    profile: &str,
+    crypto_inline_key: Option<&str>,
+) -> String {
     let mut b = String::new();
     b.push_str("v=0\r\n");
     b.push_str("o=xphone 0 0 IN IP4 ");
@@ -181,7 +195,7 @@ pub fn build_offer(ip: &str, port: i32, codecs: &[i32], direction: &str) -> Stri
     b.push_str(ip);
     b.push_str("\r\n");
     b.push_str("t=0 0\r\n");
-    b.push_str(&format!("m=audio {} RTP/AVP", port));
+    b.push_str(&format!("m=audio {} {}", port, profile));
     for c in codecs {
         b.push_str(&format!(" {}", c));
     }
@@ -189,15 +203,26 @@ pub fn build_offer(ip: &str, port: i32, codecs: &[i32], direction: &str) -> Stri
     for &c in codecs {
         if let Some(name) = codec_name(c) {
             b.push_str(&format!("a=rtpmap:{} {}\r\n", c, name));
-            if c == 101 {
-                b.push_str("a=fmtp:101 0-16\r\n");
+            if let Some(fmtp) = codec_fmtp(c) {
+                b.push_str(&format!("a=fmtp:{} {}\r\n", c, fmtp));
             }
         }
+    }
+    if let Some(key) = crypto_inline_key {
+        b.push_str(&format!(
+            "a=crypto:1 AES_CM_128_HMAC_SHA1_80 inline:{}\r\n",
+            key
+        ));
     }
     b.push_str("a=");
     b.push_str(direction);
     b.push_str("\r\n");
     b
+}
+
+/// Creates an SDP offer string.
+pub fn build_offer(ip: &str, port: i32, codecs: &[i32], direction: &str) -> String {
+    build_offer_inner(ip, port, codecs, direction, "RTP/AVP", None)
 }
 
 /// Creates an SDP answer that only includes codecs present in both
@@ -231,37 +256,14 @@ pub fn build_offer_srtp(
     direction: &str,
     crypto_inline_key: &str,
 ) -> String {
-    let mut b = String::new();
-    b.push_str("v=0\r\n");
-    b.push_str("o=xphone 0 0 IN IP4 ");
-    b.push_str(ip);
-    b.push_str("\r\n");
-    b.push_str("s=xphone\r\n");
-    b.push_str("c=IN IP4 ");
-    b.push_str(ip);
-    b.push_str("\r\n");
-    b.push_str("t=0 0\r\n");
-    b.push_str(&format!("m=audio {} RTP/SAVP", port));
-    for c in codecs {
-        b.push_str(&format!(" {}", c));
-    }
-    b.push_str("\r\n");
-    for &c in codecs {
-        if let Some(name) = codec_name(c) {
-            b.push_str(&format!("a=rtpmap:{} {}\r\n", c, name));
-            if c == 101 {
-                b.push_str("a=fmtp:101 0-16\r\n");
-            }
-        }
-    }
-    b.push_str(&format!(
-        "a=crypto:1 AES_CM_128_HMAC_SHA1_80 inline:{}\r\n",
-        crypto_inline_key
-    ));
-    b.push_str("a=");
-    b.push_str(direction);
-    b.push_str("\r\n");
-    b
+    build_offer_inner(
+        ip,
+        port,
+        codecs,
+        direction,
+        "RTP/SAVP",
+        Some(crypto_inline_key),
+    )
 }
 
 /// Creates an SDP answer with SRTP support.


### PR DESCRIPTION
## Summary
- Add Opus codec (PT 111) behind optional `opus-codec` feature flag — requires libopus C library
- `OpusProcessor` encodes/decodes at 8kHz mono VoIP mode with 48kHz RTP clock per RFC 7587
- Fallible constructor (`new() -> Option<Self>`) with `tracing::warn!` on encode/decode errors
- SDP: `a=fmtp:111 minptime=20;useinbandfec=0` emitted for Opus offers
- Refactored `build_offer`/`build_offer_srtp` into shared `build_offer_inner` + `codec_fmtp()` lookup
- CI: added `libopus-dev`, opus-codec clippy/test/build steps

## Test plan
- [x] `cargo fmt && cargo clippy -- -D warnings && cargo test` — 415 tests pass (default build unchanged)
- [x] `cargo clippy --features opus-codec --all-targets -- -D warnings` — clean
- [x] `cargo test --features opus-codec` — 422 tests pass (+7 opus, +1 codec mod, −1 no-feature)
- [ ] CI passes on Linux (libopus-dev install + feature matrix)