### PR TITLE
Add G.729 codec support (PT 18)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,8 @@ jobs:
         run: cargo clippy --all-targets -- -D warnings
       - name: Clippy (opus-codec feature)
         run: cargo clippy --features opus-codec --all-targets -- -D warnings
+      - name: Clippy (g729-codec feature)
+        run: cargo clippy --features g729-codec --all-targets -- -D warnings
       - name: Clippy (cli feature)
         run: cargo clippy --example sipcli --features cli -- -D warnings
 
@@ -44,6 +46,8 @@ jobs:
         run: cargo test --verbose
       - name: Test (opus-codec feature)
         run: cargo test --features opus-codec --verbose
+      - name: Test (g729-codec feature)
+        run: cargo test --features g729-codec --verbose
       - name: Test (release)
         run: cargo test --release
 
@@ -86,5 +90,7 @@ jobs:
       - name: Build library (opus-codec)
         if: runner.os == 'Linux'
         run: cargo build --features opus-codec
+      - name: Build library (g729-codec)
+        run: cargo build --features g729-codec
       - name: Build sipcli
         run: cargo build --example sipcli --features cli --release

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -102,6 +102,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
 name = "audiopus_sys"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -605,6 +611,15 @@ dependencies = [
  "futures-task",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "g729-sys"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c0115766e9b2dcbc585946d207299fe2fce9bf0b8d4ba0d3592c6e0f66fe116"
+dependencies = [
+ "anyhow",
 ]
 
 [[package]]
@@ -2056,6 +2071,7 @@ dependencies = [
  "crossterm",
  "dirs-next",
  "fakepbx",
+ "g729-sys",
  "getrandom 0.2.17",
  "hmac",
  "md5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,7 +74,12 @@ optional = true
 version = "0.3"
 optional = true
 
+[dependencies.g729-sys]
+version = "0.1"
+optional = true
+
 [features]
 integration = []
 opus-codec = ["opus"]
+g729-codec = ["g729-sys"]
 cli = ["ratatui", "crossterm", "clap", "serde", "serde_yaml", "dirs-next", "cpal"]

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: fmt clippy build test test-integration test-docker test-all docker-up docker-down lint sipcli check
+.PHONY: fmt clippy build test test-g729 test-integration test-docker test-all docker-up docker-down lint sipcli check
 
 fmt:
 	cargo fmt
@@ -11,6 +11,9 @@ build:
 
 test:
 	cargo test
+
+test-g729:
+	cargo test --features g729-codec -- g729
 
 test-integration:
 	cargo test --features integration --test integration_test -- --nocapture --test-threads=1

--- a/src/codec/g729_codec.rs
+++ b/src/codec/g729_codec.rs
@@ -1,0 +1,211 @@
+// G.729 codec implementation (ITU-T G.729, payload type 18).
+//
+// Uses the `g729-sys` crate (pure Rust port of bcg729) gated behind the
+// `g729-codec` feature. G.729 operates on 10ms / 80-sample frames at 8kHz,
+// producing 10 bytes per frame. The pipeline uses 20ms / 160-sample frames,
+// so this processor splits/merges internally (transparent to pipeline).
+//
+// **No Annex B (VAD/CNG)**: g729-sys has VAD stubbed out. SDP advertises
+// `annexb=no` to tell remote endpoints not to send SID frames.
+
+use super::CodecProcessor;
+
+const PAYLOAD_TYPE: u8 = 18;
+const CLOCK_RATE: u32 = 8000;
+const SAMPLES_PER_FRAME: u32 = 160; // 20ms at 8kHz (pipeline frame size)
+const G729_FRAME_SAMPLES: usize = 80; // 10ms at 8kHz (codec native)
+const G729_FRAME_BYTES: usize = 10; // 10 bytes per 10ms frame
+
+pub struct G729Processor {
+    enc: g729_sys::Encoder,
+    dec: g729_sys::Decoder,
+}
+
+impl G729Processor {
+    pub fn new() -> Option<Self> {
+        let enc = g729_sys::Encoder::new(false).ok()?;
+        let dec = g729_sys::Decoder::new().ok()?;
+        Some(Self { enc, dec })
+    }
+}
+
+impl CodecProcessor for G729Processor {
+    fn decode(&mut self, payload: &[u8]) -> Vec<i16> {
+        // Split payload into 10-byte chunks, decode each into 80 samples.
+        // Handles both 10-byte (single 10ms) and 20-byte (standard 20ms) payloads,
+        // as well as any multiple. Trailing bytes < 10 are ignored.
+        let num_frames = payload.len() / G729_FRAME_BYTES;
+        if num_frames == 0 {
+            return Vec::new();
+        }
+        let mut out = Vec::with_capacity(num_frames * G729_FRAME_SAMPLES);
+        for i in 0..num_frames {
+            let chunk = &payload[i * G729_FRAME_BYTES..(i + 1) * G729_FRAME_BYTES];
+            let samples = self.dec.decode(chunk, false, false, false);
+            out.extend_from_slice(&samples);
+        }
+        out
+    }
+
+    fn encode(&mut self, samples: &[i16]) -> Vec<u8> {
+        // Split 160 samples into 2×80, encode each into 10 bytes → 20 bytes total.
+        let num_frames = samples.len() / G729_FRAME_SAMPLES;
+        if num_frames == 0 {
+            return Vec::new();
+        }
+        let mut out = Vec::with_capacity(num_frames * G729_FRAME_BYTES);
+        for i in 0..num_frames {
+            let start = i * G729_FRAME_SAMPLES;
+            let frame: &[i16; 80] = samples[start..start + G729_FRAME_SAMPLES]
+                .try_into()
+                .expect("slice is exactly 80 samples");
+            let encoded = self.enc.encode(frame);
+            out.extend_from_slice(&encoded);
+        }
+        out
+    }
+
+    fn payload_type(&self) -> u8 {
+        PAYLOAD_TYPE
+    }
+
+    fn clock_rate(&self) -> u32 {
+        CLOCK_RATE
+    }
+
+    fn samples_per_frame(&self) -> u32 {
+        SAMPLES_PER_FRAME
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const PCM_FRAME_SIZE: usize = 160; // 20ms at 8kHz
+
+    #[test]
+    fn interface() {
+        let p = G729Processor::new().unwrap();
+        assert_eq!(p.payload_type(), 18);
+        assert_eq!(p.clock_rate(), 8000);
+        assert_eq!(p.samples_per_frame(), 160);
+    }
+
+    #[test]
+    fn round_trip_silence() {
+        let mut p = G729Processor::new().unwrap();
+        let silence = vec![0i16; PCM_FRAME_SIZE];
+        let encoded = p.encode(&silence);
+        assert!(!encoded.is_empty());
+        let decoded = p.decode(&encoded);
+        assert_eq!(decoded.len(), PCM_FRAME_SIZE);
+        // Silence should decode to near-zero values
+        for &s in &decoded {
+            assert!(s.abs() < 500, "expected near-silence, got {}", s);
+        }
+    }
+
+    #[test]
+    fn round_trip_tone() {
+        let mut p = G729Processor::new().unwrap();
+        let tone: Vec<i16> = (0..PCM_FRAME_SIZE)
+            .map(|i| {
+                let t = i as f64 / CLOCK_RATE as f64;
+                (f64::sin(2.0 * std::f64::consts::PI * 440.0 * t) * 16000.0) as i16
+            })
+            .collect();
+        let encoded = p.encode(&tone);
+        assert!(!encoded.is_empty());
+        let decoded = p.decode(&encoded);
+        assert_eq!(decoded.len(), PCM_FRAME_SIZE);
+        // Should have non-trivial energy
+        let energy: i64 = decoded.iter().map(|&s| (s as i64) * (s as i64)).sum();
+        assert!(energy > 0, "decoded tone should have energy");
+    }
+
+    #[test]
+    fn compression() {
+        let mut p = G729Processor::new().unwrap();
+        let pcm = vec![0i16; PCM_FRAME_SIZE];
+        let encoded = p.encode(&pcm);
+        // G.729 produces 20 bytes for 160 samples (320 bytes raw PCM)
+        assert_eq!(encoded.len(), 20);
+        assert!(
+            encoded.len() < PCM_FRAME_SIZE * 2,
+            "encoded {} bytes >= raw {} bytes",
+            encoded.len(),
+            PCM_FRAME_SIZE * 2
+        );
+    }
+
+    #[test]
+    fn output_size() {
+        let mut p = G729Processor::new().unwrap();
+        let tone: Vec<i16> = (0..PCM_FRAME_SIZE)
+            .map(|i| ((i as f64 * 0.1).sin() * 20000.0) as i16)
+            .collect();
+        let encoded = p.encode(&tone);
+        // 160 samples → 2 × 10-byte frames = 20 bytes exactly
+        assert_eq!(encoded.len(), 20);
+    }
+
+    #[test]
+    fn stateful_encoding() {
+        let mut p = G729Processor::new().unwrap();
+        let pcm = vec![1000i16; PCM_FRAME_SIZE];
+        let first = p.encode(&pcm);
+        let second = p.encode(&pcm);
+        // G.729 is stateful — second frame may differ from first.
+        // Both should be valid non-empty output.
+        assert!(!first.is_empty());
+        assert!(!second.is_empty());
+    }
+
+    #[test]
+    fn multi_frame_round_trip() {
+        let mut p = G729Processor::new().unwrap();
+        for i in 0..5 {
+            let pcm: Vec<i16> = (0..PCM_FRAME_SIZE)
+                .map(|j| ((j as f64 + i as f64 * 100.0) * 0.05).sin() as i16 * 10000)
+                .collect();
+            let encoded = p.encode(&pcm);
+            assert!(!encoded.is_empty(), "frame {} encode failed", i);
+            let decoded = p.decode(&encoded);
+            assert_eq!(decoded.len(), PCM_FRAME_SIZE, "frame {} decode size", i);
+        }
+    }
+
+    #[test]
+    fn single_10byte_decode() {
+        // Remote endpoint sends a single 10ms frame (10 bytes).
+        // Decoder should produce 80 samples.
+        let mut p = G729Processor::new().unwrap();
+        // Encode a full 160-sample frame, take only the first 10 bytes (first 10ms).
+        let pcm = vec![0i16; PCM_FRAME_SIZE];
+        let encoded = p.encode(&pcm);
+        assert_eq!(encoded.len(), 20);
+        let first_frame = &encoded[..10];
+        let decoded = p.decode(first_frame);
+        assert_eq!(decoded.len(), G729_FRAME_SAMPLES);
+    }
+
+    #[test]
+    fn odd_payload_handling() {
+        // Payloads that aren't a multiple of 10 bytes: trailing bytes are ignored.
+        let mut p = G729Processor::new().unwrap();
+        let pcm = vec![0i16; PCM_FRAME_SIZE];
+        let encoded = p.encode(&pcm);
+        // Append 3 garbage bytes
+        let mut odd = encoded.clone();
+        odd.extend_from_slice(&[0xFF, 0xFE, 0xFD]);
+        let decoded = p.decode(&odd);
+        // Should decode exactly 2 frames (20 bytes), ignoring the 3 trailing bytes
+        assert_eq!(decoded.len(), PCM_FRAME_SIZE);
+
+        // Payload shorter than one frame (e.g. 5 bytes) → empty
+        let short = &encoded[..5];
+        let decoded_short = p.decode(short);
+        assert!(decoded_short.is_empty());
+    }
+}

--- a/src/codec/mod.rs
+++ b/src/codec/mod.rs
@@ -1,4 +1,6 @@
 pub mod g722;
+#[cfg(feature = "g729-codec")]
+pub mod g729_codec;
 #[cfg(feature = "opus-codec")]
 pub mod opus_codec;
 pub mod pcma;
@@ -25,6 +27,8 @@ pub fn new_codec_processor(payload_type: i32, pcm_rate: i32) -> Option<Box<dyn C
         0 => Some(Box::new(pcmu::PcmuProcessor::new())),
         8 => Some(Box::new(pcma::PcmaProcessor::new())),
         9 => Some(Box::new(g722::G722Processor::new(pcm_rate as u32))),
+        #[cfg(feature = "g729-codec")]
+        18 => g729_codec::G729Processor::new().map(|p| Box::new(p) as Box<dyn CodecProcessor>),
         #[cfg(feature = "opus-codec")]
         111 => opus_codec::OpusProcessor::new().map(|p| Box::new(p) as Box<dyn CodecProcessor>),
         _ => None,
@@ -62,6 +66,21 @@ mod tests {
     #[test]
     fn codec_processor_unknown_returns_none() {
         assert!(new_codec_processor(99, 8000).is_none());
+    }
+
+    #[cfg(not(feature = "g729-codec"))]
+    #[test]
+    fn codec_processor_g729_without_feature_returns_none() {
+        assert!(new_codec_processor(18, 8000).is_none());
+    }
+
+    #[cfg(feature = "g729-codec")]
+    #[test]
+    fn codec_processor_g729_with_feature_returns_some() {
+        let cp = new_codec_processor(18, 8000).unwrap();
+        assert_eq!(cp.payload_type(), 18);
+        assert_eq!(cp.clock_rate(), 8000);
+        assert_eq!(cp.samples_per_frame(), 160);
     }
 
     #[cfg(not(feature = "opus-codec"))]

--- a/src/sdp.rs
+++ b/src/sdp.rs
@@ -99,6 +99,7 @@ fn codec_name(pt: i32) -> Option<&'static str> {
         0 => Some("PCMU/8000"),
         8 => Some("PCMA/8000"),
         9 => Some("G722/8000"),
+        18 => Some("G729/8000"),
         101 => Some("telephone-event/8000"),
         111 => Some("opus/48000/2"),
         _ => None,
@@ -107,6 +108,7 @@ fn codec_name(pt: i32) -> Option<&'static str> {
 
 fn codec_fmtp(pt: i32) -> Option<&'static str> {
     match pt {
+        18 => Some("annexb=no"),
         101 => Some("0-16"),
         111 => Some("minptime=20;useinbandfec=0"),
         _ => None,

--- a/src/types.rs
+++ b/src/types.rs
@@ -222,6 +222,8 @@ pub enum Codec {
     PCMA = 8,
     /// G.722 (payload type 9).
     G722 = 9,
+    /// G.729 (payload type 18).
+    G729 = 18,
     /// Opus (payload type 111).
     Opus = 111,
 }
@@ -238,6 +240,7 @@ impl Codec {
             0 => Some(Codec::PCMU),
             8 => Some(Codec::PCMA),
             9 => Some(Codec::G722),
+            18 => Some(Codec::G729),
             111 => Some(Codec::Opus),
             _ => None,
         }
@@ -250,6 +253,7 @@ impl fmt::Display for Codec {
             Codec::PCMU => write!(f, "PCMU"),
             Codec::PCMA => write!(f, "PCMA"),
             Codec::G722 => write!(f, "G722"),
+            Codec::G729 => write!(f, "G729"),
             Codec::Opus => write!(f, "Opus"),
         }
     }
@@ -290,6 +294,7 @@ mod tests {
         assert_eq!(Codec::PCMU.payload_type(), 0);
         assert_eq!(Codec::PCMA.payload_type(), 8);
         assert_eq!(Codec::G722.payload_type(), 9);
+        assert_eq!(Codec::G729.payload_type(), 18);
         assert_eq!(Codec::Opus.payload_type(), 111);
     }
 
@@ -298,6 +303,7 @@ mod tests {
         assert_eq!(Codec::from_payload_type(0), Some(Codec::PCMU));
         assert_eq!(Codec::from_payload_type(8), Some(Codec::PCMA));
         assert_eq!(Codec::from_payload_type(9), Some(Codec::G722));
+        assert_eq!(Codec::from_payload_type(18), Some(Codec::G729));
         assert_eq!(Codec::from_payload_type(111), Some(Codec::Opus));
         assert_eq!(Codec::from_payload_type(99), None);
     }
@@ -306,6 +312,7 @@ mod tests {
     fn codec_display() {
         assert_eq!(Codec::PCMU.to_string(), "PCMU");
         assert_eq!(Codec::G722.to_string(), "G722");
+        assert_eq!(Codec::G729.to_string(), "G729");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add optional `g729-codec` feature using `g729-sys` crate (pure Rust, MIT)
- G729Processor splits/merges 10ms native frames to match pipeline's 20ms frame size
- SDP advertises `annexb=no` (VAD/CNG not supported by g729-sys)
- 10 new tests, CI steps for clippy/test/build, `make test-g729` target

## Test plan
- [x] `cargo fmt && cargo clippy -- -D warnings && cargo test` (default build unchanged, 531 tests)
- [x] `cargo test --features g729-codec` (540 tests, +10 G.729)
- [x] `make test-g729` runs only G.729 tests
- [x] CI: clippy, test, and build steps added for `g729-codec` feature