### PR TITLE
Add video SDP multi-media support (PR 1/4)

### DIFF
--- a/PLAN-VIDEO.md
+++ b/PLAN-VIDEO.md
@@ -1,0 +1,162 @@
+# Video Support (H.264 / VP8) — Implementation Plan
+
+## Overview
+Add video calling to xphone-rust. The library handles SDP negotiation, RTP packetization/depacketization, and frame assembly. It does NOT encode/decode video — consumers use platform APIs (VideoToolbox, VA-API, etc.) and feed raw encoded frames in/out.
+
+## API (final agreed design)
+
+```rust
+// --- Types ---
+pub enum VideoCodec { H264, VP8 }
+
+pub struct VideoFrame {
+    pub codec: VideoCodec,
+    pub timestamp: u32,
+    pub is_keyframe: bool,
+    pub data: Vec<u8>,  // H.264: Annex-B NAL units, VP8: raw frame
+}
+
+// --- DialOptions ---
+pub struct DialOptions {
+    pub video: bool,                     // enable video in SDP offer
+    pub video_codecs: Vec<VideoCodec>,   // preference order, default: [H264, VP8]
+    // video_bandwidth deferred (REMB/TMMBR is its own feature)
+}
+
+// --- Call ---
+impl Call {
+    // Mute all outbound (audio + video) — backwards compatible
+    fn mute() -> Result<()>;
+    fn unmute() -> Result<()>;
+
+    // Granular per-stream mute
+    fn mute_audio() -> Result<()>;
+    fn unmute_audio() -> Result<()>;
+    fn mute_video() -> Result<()>;
+    fn unmute_video() -> Result<()>;
+
+    // Video — None/false if audio-only call
+    fn has_video() -> bool;
+    fn video_codec() -> Option<VideoCodec>;
+
+    // Assembled frames (common case — library handles FU-A reassembly/fragmentation)
+    fn video_reader() -> Option<Receiver<VideoFrame>>;
+    fn video_writer() -> Option<Sender<VideoFrame>>;
+
+    // Raw video RTP passthrough (recording, forwarding, power users)
+    fn video_rtp_reader() -> Option<Receiver<RtpPacket>>;
+    fn video_rtp_writer() -> Option<Sender<RtpPacket>>;
+
+    // Request keyframe from remote (RTCP PLI)
+    fn request_keyframe() -> Result<()>;
+}
+```
+
+---
+
+## PR 1: SDP multi-media
+
+Extend SDP building/parsing to support multiple m= lines. No video flowing yet — audio behavior unchanged.
+
+- [x] Add `VideoCodec` enum to `types.rs` (H264, VP8) with Display, payload type mappings
+- [x] Add `video` and `video_codecs` fields to `DialOptions`
+- [x] Extend `sdp.rs`: build `m=video` line with dynamic PT (96+)
+- [x] Extend `sdp.rs`: `a=rtpmap` for H.264 (`H264/90000`) and VP8 (`VP8/90000`)
+- [x] Extend `sdp.rs`: `a=fmtp` for H.264 (`profile-level-id=42e01f;packetization-mode=1`)
+- [x] Extend `sdp.rs`: `a=rtcp-fb` lines (`nack`, `nack pli`, `ccm fir`)
+- [x] Extend SDP parser: extract video codec, PT, fmtp from remote SDP
+- [x] Extend SDP parser: handle multiple m= sections (audio + video)
+- [x] Tests: SDP offer with video, SDP answer parsing, audio-only backwards compat
+- [x] Verify: `cargo fmt && cargo clippy -- -D warnings && cargo test` all pass
+
+## PR 2: MediaStream refactor (PURE REFACTOR — audio only)
+
+Extract monolithic media pipeline into a per-stream `MediaStream` abstraction. Call holds a `Vec<MediaStream>`, audio is `streams[0]`. Zero new features — all existing tests must pass unchanged.
+
+- [ ] Define `MediaStream` struct (owns: socket, jitter buffer, RTP state, codec, RTCP context)
+- [ ] Extract current `media.rs` audio pipeline into `MediaStream`
+- [ ] Call holds `Vec<MediaStream>`, `streams[0]` = audio
+- [ ] Per-stream mute flag (audio stream only for now)
+- [ ] Add `mute_audio()`/`unmute_audio()` methods on Call
+- [ ] Update `mute()`/`unmute()` to mute all streams (backwards compatible)
+- [ ] DTMF stays on audio stream (stream index 0)
+- [ ] Hold/resume operates per-stream (`a=sendonly`/`a=inactive` per m= line)
+- [ ] Per-stream RTCP with correct clock rate
+- [ ] ALL existing tests pass unchanged (this is the acceptance criteria)
+- [ ] Tests: per-stream mute, mute-all behavior
+- [ ] Verify: `cargo fmt && cargo clippy -- -D warnings && cargo test` all pass
+
+## PR 3: Video plumbing
+
+Wire up the video stream. Second RTP/RTCP socket pair, video MediaStream, channels on Call.
+
+- [ ] Allocate second RTP+RTCP socket pair when video negotiated
+- [ ] Create video `MediaStream` (stream index 1) with 90kHz clock
+- [ ] `VideoFrame` struct in `types.rs`
+- [ ] `video_reader()`/`video_writer()` channels on Call (assembled frames)
+- [ ] `video_rtp_reader()`/`video_rtp_writer()` channels on Call (raw RTP passthrough)
+- [ ] `has_video()`, `video_codec()` query methods
+- [ ] `mute_video()`/`unmute_video()` — stops sending on video stream
+- [ ] `request_keyframe()` — sends RTCP PLI (RFC 4585)
+- [ ] Add RTCP PLI/FIR packet building to `rtcp.rs`
+- [ ] Wire video in `phone.rs` dial/incoming paths (pass video option through)
+- [ ] Wire video SDP in call setup (offer with video, parse answer)
+- [ ] Tests: video stream creation, channel wiring, mute_video, PLI generation
+- [ ] Verify: `cargo fmt && cargo clippy -- -D warnings && cargo test` all pass
+
+## PR 4: H.264 + VP8 packetizers
+
+RTP-level frame assembly and fragmentation. This is the deepest work.
+
+### H.264 (RFC 6184)
+- [ ] `VideoDepacketizer` trait: `fn depacketize(&mut self, pkt: &RtpPacket) -> Option<VideoFrame>`
+- [ ] `VideoPacketizer` trait: `fn packetize(&mut self, frame: &VideoFrame, mtu: usize) -> Vec<Vec<u8>>`
+- [ ] `H264Depacketizer`: Single NAL unit mode (type 1-23)
+- [ ] `H264Depacketizer`: STAP-A aggregation (type 24) — multiple NALs in one RTP
+- [ ] `H264Depacketizer`: FU-A fragmentation (type 28) — stateful reassembly across packets
+- [ ] `H264Depacketizer`: frame boundary detection (marker bit + timestamp change)
+- [ ] `H264Depacketizer`: keyframe detection (NAL type 5 = IDR)
+- [ ] `H264Depacketizer`: SPS/PPS parameter set handling
+- [ ] `H264Packetizer`: fragment NAL units > MTU into FU-A packets
+- [ ] `H264Packetizer`: small NALs sent as Single NAL unit
+- [ ] Tests: FU-A reassembly, STAP-A, single NAL, keyframe detect, fragmentation round-trip
+
+### VP8 (RFC 7741)
+- [ ] `VP8Depacketizer`: VP8 payload descriptor parsing (S bit, PID, extensions)
+- [ ] `VP8Depacketizer`: frame assembly from multiple RTP packets
+- [ ] `VP8Depacketizer`: keyframe detection (VP8 frame header P bit)
+- [ ] `VP8Packetizer`: split frame into MTU-sized payloads with correct descriptors
+- [ ] Tests: VP8 depacketize/packetize round-trip, keyframe detection
+
+### Integration
+- [ ] Wire depacketizers into video `MediaStream` inbound path
+- [ ] Wire packetizers into video `MediaStream` outbound path
+- [ ] Register H264/VP8 by dynamic PT from SDP negotiation
+- [ ] Integration test: video call through Docker Asterisk (if Asterisk supports video passthrough)
+- [ ] Verify: `cargo fmt && cargo clippy -- -D warnings && cargo test` all pass
+
+---
+
+## Deferred (not in scope)
+- Video encode/decode (consumer's job — platform APIs)
+- Bandwidth estimation (REMB, TWCC, TMMBR)
+- Simulcast / SVC layers
+- H.265 / AV1
+- BUNDLE (audio + video on same port)
+- SRTP for video (reuse existing, just needs second context)
+- Camera capture / display rendering
+
+## Files (expected)
+
+| File | What |
+|------|------|
+| `src/types.rs` | `VideoCodec`, `VideoFrame` |
+| `src/sdp.rs` | Multi-media m= lines, video codec params |
+| `src/media.rs` | `MediaStream` abstraction, video stream |
+| `src/video/mod.rs` | `VideoDepacketizer`, `VideoPacketizer` traits |
+| `src/video/h264.rs` | H.264 FU-A/STAP-A/Single NAL packetizer/depacketizer |
+| `src/video/vp8.rs` | VP8 packetizer/depacketizer |
+| `src/rtcp.rs` | PLI/FIR packet building |
+| `src/call.rs` | Video channels, per-stream mute, request_keyframe |
+| `src/phone.rs` | Video option in dial/incoming |
+| `src/config.rs` | `video`/`video_codecs` in DialOptions |

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 
 use crate::sip::conn::TlsConfig;
-use crate::types::Codec;
+use crate::types::{Codec, VideoCodec};
 
 /// Selects how DTMF digits are sent and received.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -280,6 +280,11 @@ pub struct DialOptions {
     pub timeout: Duration,
     /// Codec list that overrides the phone-level preferences for this call.
     pub codec_override: Vec<Codec>,
+    /// Enable video in the SDP offer.
+    pub video: bool,
+    /// Video codecs in preference order. Defaults to `[H264, VP8]` when
+    /// `video` is enabled. Only used when `video` is `true`.
+    pub video_codecs: Vec<VideoCodec>,
 }
 
 impl Default for DialOptions {
@@ -290,6 +295,8 @@ impl Default for DialOptions {
             early_media: false,
             timeout: Duration::from_secs(30),
             codec_override: Vec::new(),
+            video: false,
+            video_codecs: Vec::new(),
         }
     }
 }
@@ -334,6 +341,22 @@ impl DialOptionsBuilder {
     /// Overrides the phone-level codec preferences for this call.
     pub fn codec_override(mut self, codecs: Vec<Codec>) -> Self {
         self.opts.codec_override = codecs;
+        self
+    }
+
+    /// Enables video in the SDP offer. Also sets default video codecs
+    /// `[H264, VP8]` if none were explicitly set.
+    pub fn video(mut self) -> Self {
+        self.opts.video = true;
+        if self.opts.video_codecs.is_empty() {
+            self.opts.video_codecs = vec![VideoCodec::H264, VideoCodec::VP8];
+        }
+        self
+    }
+
+    /// Sets the preferred video codecs (default: `[H264, VP8]`).
+    pub fn video_codecs(mut self, codecs: Vec<VideoCodec>) -> Self {
+        self.opts.video_codecs = codecs;
         self
     }
 
@@ -440,5 +463,41 @@ mod tests {
         assert!(opts.early_media);
         assert_eq!(opts.timeout, Duration::from_secs(60));
         assert_eq!(opts.codec_override, vec![Codec::G722]);
+    }
+
+    #[test]
+    fn dial_options_video_default_off() {
+        let opts = DialOptions::default();
+        assert!(!opts.video);
+        assert!(opts.video_codecs.is_empty());
+    }
+
+    #[test]
+    fn dial_options_builder_video() {
+        let opts = DialOptionsBuilder::new()
+            .video()
+            .video_codecs(vec![VideoCodec::H264, VideoCodec::VP8])
+            .build();
+        assert!(opts.video);
+        assert_eq!(opts.video_codecs, vec![VideoCodec::H264, VideoCodec::VP8]);
+    }
+
+    #[test]
+    fn dial_options_builder_video_default_codecs() {
+        // .video() without .video_codecs() should default to [H264, VP8].
+        let opts = DialOptionsBuilder::new().video().build();
+        assert!(opts.video);
+        assert_eq!(opts.video_codecs, vec![VideoCodec::H264, VideoCodec::VP8]);
+    }
+
+    #[test]
+    fn dial_options_builder_video_h264_only() {
+        // Explicit .video_codecs() before .video() is preserved.
+        let opts = DialOptionsBuilder::new()
+            .video_codecs(vec![VideoCodec::H264])
+            .video()
+            .build();
+        assert!(opts.video);
+        assert_eq!(opts.video_codecs, vec![VideoCodec::H264]);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,5 +37,5 @@ pub use sip::conn::TlsConfig;
 pub use subscription::SubId;
 pub use types::{
     CallState, Codec, Direction, EndReason, ExtensionState, ExtensionStatus, NotifyEvent,
-    PhoneState, SipMessage, SubState, VoicemailStatus,
+    PhoneState, SipMessage, SubState, VideoCodec, VoicemailStatus,
 };

--- a/src/sdp.rs
+++ b/src/sdp.rs
@@ -1,5 +1,6 @@
 use crate::error::Error;
 use crate::ice::IceSdpParams;
+use crate::types::VideoCodec;
 
 /// SDP direction: send and receive.
 pub const DIR_SEND_RECV: &str = "sendrecv";
@@ -32,6 +33,8 @@ pub struct Session {
 /// A single media description from an SDP m= line.
 #[derive(Debug, Clone)]
 pub struct MediaDesc {
+    /// Media type: `"audio"` or `"video"`.
+    pub media_type: String,
     /// Media port number.
     pub port: i32,
     /// RTP payload type numbers offered/answered.
@@ -44,6 +47,12 @@ pub struct MediaDesc {
     pub crypto: Vec<CryptoAttr>,
     /// Raw `a=candidate:` lines.
     pub candidates: Vec<String>,
+    /// `a=rtpmap:` entries: `(payload_type, encoding_name)`.
+    pub rtpmap: Vec<(i32, String)>,
+    /// `a=fmtp:` entries: `(payload_type, params)`.
+    pub fmtp: Vec<(i32, String)>,
+    /// `a=rtcp-fb:` entries: `(payload_type, feedback_type)`.
+    pub rtcp_fb: Vec<(i32, String)>,
 }
 
 /// Parsed SRTP crypto attribute from an `a=crypto:` SDP line.
@@ -91,6 +100,31 @@ impl Session {
     /// Returns the first crypto attribute from the first media line, if any.
     pub fn first_crypto(&self) -> Option<&CryptoAttr> {
         self.media.first().and_then(|m| m.crypto.first())
+    }
+
+    /// Returns the first audio media description, if any.
+    pub fn audio_media(&self) -> Option<&MediaDesc> {
+        self.media.iter().find(|m| m.media_type == "audio")
+    }
+
+    /// Returns the first video media description, if any.
+    pub fn video_media(&self) -> Option<&MediaDesc> {
+        self.media.iter().find(|m| m.media_type == "video")
+    }
+
+    /// Returns true if this SDP includes a video m= line.
+    pub fn has_video(&self) -> bool {
+        self.video_media().is_some()
+    }
+
+    /// Identifies the negotiated video codec from the video m= line's rtpmap.
+    pub fn video_codec(&self) -> Option<VideoCodec> {
+        let vm = self.video_media()?;
+        let pt = *vm.codecs.first()?;
+        vm.rtpmap
+            .iter()
+            .find(|(p, _)| *p == pt)
+            .and_then(|(_, name)| VideoCodec::from_rtpmap_name(name))
     }
 }
 
@@ -149,6 +183,7 @@ pub fn parse(raw: &str) -> crate::error::Result<Session> {
             b'm' => {
                 let parts: Vec<&str> = val.split_whitespace().collect();
                 if parts.len() >= 3 {
+                    let media_type = parts[0].to_string();
                     let port = parts[1].parse::<i32>().unwrap_or(0);
                     let profile = parts[2].to_string();
                     let codecs: Vec<i32> = parts[3..]
@@ -156,12 +191,16 @@ pub fn parse(raw: &str) -> crate::error::Result<Session> {
                         .filter_map(|s| s.parse::<i32>().ok())
                         .collect();
                     session.media.push(MediaDesc {
+                        media_type,
                         port,
                         codecs,
                         direction: String::new(),
                         profile,
                         crypto: Vec::new(),
                         candidates: Vec::new(),
+                        rtpmap: Vec::new(),
+                        fmtp: Vec::new(),
+                        rtcp_fb: Vec::new(),
                     });
                     cur_media_idx = Some(session.media.len() - 1);
                 }
@@ -173,7 +212,25 @@ pub fn parse(raw: &str) -> crate::error::Result<Session> {
                     }
                 }
                 _ => {
-                    if let Some(crypto_val) = val.strip_prefix("crypto:") {
+                    if let Some(rtpmap_val) = val.strip_prefix("rtpmap:") {
+                        if let Some(idx) = cur_media_idx {
+                            if let Some(pair) = parse_pt_value(rtpmap_val) {
+                                session.media[idx].rtpmap.push(pair);
+                            }
+                        }
+                    } else if let Some(fmtp_val) = val.strip_prefix("fmtp:") {
+                        if let Some(idx) = cur_media_idx {
+                            if let Some(pair) = parse_pt_value(fmtp_val) {
+                                session.media[idx].fmtp.push(pair);
+                            }
+                        }
+                    } else if let Some(fb_val) = val.strip_prefix("rtcp-fb:") {
+                        if let Some(idx) = cur_media_idx {
+                            if let Some(pair) = parse_pt_value(fb_val) {
+                                session.media[idx].rtcp_fb.push(pair);
+                            }
+                        }
+                    } else if let Some(crypto_val) = val.strip_prefix("crypto:") {
                         if let Some(idx) = cur_media_idx {
                             if let Some(attr) = parse_crypto_val(crypto_val) {
                                 session.media[idx].crypto.push(attr);
@@ -200,6 +257,31 @@ pub fn parse(raw: &str) -> crate::error::Result<Session> {
         return Err(Error::Sdp("no v= line found".into()));
     }
     Ok(session)
+}
+
+/// Appends media-level crypto, ICE, and direction attributes.
+fn write_media_attrs(
+    b: &mut String,
+    direction: &str,
+    crypto_inline_key: Option<&str>,
+    ice: Option<&IceSdpParams>,
+) {
+    if let Some(key) = crypto_inline_key {
+        b.push_str(&format!(
+            "a=crypto:1 AES_CM_128_HMAC_SHA1_80 inline:{}\r\n",
+            key
+        ));
+    }
+    if let Some(ice_params) = ice {
+        b.push_str(&format!("a=ice-ufrag:{}\r\n", ice_params.ufrag));
+        b.push_str(&format!("a=ice-pwd:{}\r\n", ice_params.pwd));
+        for cand in &ice_params.candidates {
+            b.push_str(&format!("a=candidate:{}\r\n", cand.to_sdp_value()));
+        }
+    }
+    b.push_str("a=");
+    b.push_str(direction);
+    b.push_str("\r\n");
 }
 
 fn build_offer_inner(
@@ -240,23 +322,7 @@ fn build_offer_inner(
             }
         }
     }
-    if let Some(key) = crypto_inline_key {
-        b.push_str(&format!(
-            "a=crypto:1 AES_CM_128_HMAC_SHA1_80 inline:{}\r\n",
-            key
-        ));
-    }
-    // ICE attributes (media-level).
-    if let Some(ice_params) = ice {
-        b.push_str(&format!("a=ice-ufrag:{}\r\n", ice_params.ufrag));
-        b.push_str(&format!("a=ice-pwd:{}\r\n", ice_params.pwd));
-        for cand in &ice_params.candidates {
-            b.push_str(&format!("a=candidate:{}\r\n", cand.to_sdp_value()));
-        }
-    }
-    b.push_str("a=");
-    b.push_str(direction);
-    b.push_str("\r\n");
+    write_media_attrs(&mut b, direction, crypto_inline_key, ice);
     b
 }
 
@@ -375,6 +441,192 @@ fn intersect_codecs(local_prefs: &[i32], remote: &[i32]) -> Vec<i32> {
         .copied()
         .filter(|c| set.contains(c))
         .collect()
+}
+
+/// Parses `"<PT> <value>"` → `(PT, value)`.
+/// Used for `a=rtpmap:`, `a=fmtp:`, and `a=rtcp-fb:` lines.
+fn parse_pt_value(val: &str) -> Option<(i32, String)> {
+    let (pt_str, rest) = val.split_once(' ')?;
+    let pt = pt_str.trim().parse::<i32>().ok()?;
+    Some((pt, rest.trim().to_string()))
+}
+
+/// Builds a video m= section (without session-level headers).
+/// `codecs` is a list of `(VideoCodec, payload_type)` pairs.
+/// For offers, use `default_payload_type()`. For answers, use the remote's PT.
+fn build_video_section(
+    port: i32,
+    codecs: &[(VideoCodec, u8)],
+    direction: &str,
+    profile: &str,
+    crypto_inline_key: Option<&str>,
+    ice: Option<&IceSdpParams>,
+) -> String {
+    let mut b = String::new();
+    b.push_str(&format!("m=video {} {}", port, profile));
+    for (_, pt) in codecs {
+        b.push_str(&format!(" {}", pt));
+    }
+    b.push_str("\r\n");
+    for (vc, pt) in codecs {
+        b.push_str(&format!("a=rtpmap:{} {}\r\n", pt, vc.rtpmap_name()));
+        if let Some(fmtp) = vc.fmtp() {
+            b.push_str(&format!("a=fmtp:{} {}\r\n", pt, fmtp));
+        }
+        for fb in vc.rtcp_fb() {
+            b.push_str(&format!("a=rtcp-fb:{} {}\r\n", pt, fb));
+        }
+    }
+    write_media_attrs(&mut b, direction, crypto_inline_key, ice);
+    b
+}
+
+/// Converts a slice of VideoCodec to (codec, default_pt) pairs for offers.
+fn default_video_pts(codecs: &[VideoCodec]) -> Vec<(VideoCodec, u8)> {
+    codecs
+        .iter()
+        .map(|vc| (*vc, vc.default_payload_type()))
+        .collect()
+}
+
+/// Creates an SDP offer with audio and video media sections.
+pub fn build_offer_video(
+    ip: &str,
+    audio_port: i32,
+    audio_codecs: &[i32],
+    video_port: i32,
+    video_codecs: &[VideoCodec],
+    direction: &str,
+) -> String {
+    let mut sdp = build_offer_inner(
+        ip,
+        audio_port,
+        audio_codecs,
+        direction,
+        "RTP/AVP",
+        None,
+        None,
+    );
+    let pts = default_video_pts(video_codecs);
+    sdp.push_str(&build_video_section(
+        video_port, &pts, direction, "RTP/AVP", None, None,
+    ));
+    sdp
+}
+
+/// Creates an SDP offer with audio + video and SRTP.
+#[allow(clippy::too_many_arguments)]
+pub fn build_offer_video_srtp(
+    ip: &str,
+    audio_port: i32,
+    audio_codecs: &[i32],
+    video_port: i32,
+    video_codecs: &[VideoCodec],
+    direction: &str,
+    audio_crypto_key: &str,
+    video_crypto_key: &str,
+) -> String {
+    let mut sdp = build_offer_inner(
+        ip,
+        audio_port,
+        audio_codecs,
+        direction,
+        "RTP/SAVP",
+        Some(audio_crypto_key),
+        None,
+    );
+    let pts = default_video_pts(video_codecs);
+    sdp.push_str(&build_video_section(
+        video_port,
+        &pts,
+        direction,
+        "RTP/SAVP",
+        Some(video_crypto_key),
+        None,
+    ));
+    sdp
+}
+
+/// Creates an SDP offer with audio + video and ICE.
+#[allow(clippy::too_many_arguments)]
+pub fn build_offer_video_ice(
+    ip: &str,
+    audio_port: i32,
+    audio_codecs: &[i32],
+    video_port: i32,
+    video_codecs: &[VideoCodec],
+    direction: &str,
+    audio_ice: &IceSdpParams,
+    video_ice: &IceSdpParams,
+) -> String {
+    let mut sdp = build_offer_inner(
+        ip,
+        audio_port,
+        audio_codecs,
+        direction,
+        "RTP/AVP",
+        None,
+        Some(audio_ice),
+    );
+    let pts = default_video_pts(video_codecs);
+    sdp.push_str(&build_video_section(
+        video_port,
+        &pts,
+        direction,
+        "RTP/AVP",
+        None,
+        Some(video_ice),
+    ));
+    sdp
+}
+
+/// Creates an SDP answer with audio + video (intersects codecs).
+///
+/// Per RFC 3264: the answer uses the remote's payload types, and includes
+/// a rejected `m=video 0` line if no common video codec is found (to preserve
+/// m= line count/order).
+#[allow(clippy::too_many_arguments)]
+pub fn build_answer_video(
+    ip: &str,
+    audio_port: i32,
+    local_audio_prefs: &[i32],
+    remote_audio: &[i32],
+    video_port: i32,
+    local_video: &[VideoCodec],
+    remote_video_rtpmap: &[(i32, String)],
+    direction: &str,
+) -> String {
+    // Audio: intersect as usual.
+    let mut audio_common = intersect_codecs(local_audio_prefs, remote_audio);
+    if audio_common.is_empty() {
+        audio_common = local_audio_prefs.to_vec();
+    }
+    // Video: intersect by matching local VideoCodec against remote rtpmap names.
+    // Use the remote's PT (RFC 3264 §6.1: answer mirrors offer's dynamic PT).
+    let video_common: Vec<(VideoCodec, u8)> = local_video
+        .iter()
+        .filter_map(|vc| {
+            remote_video_rtpmap
+                .iter()
+                .find(|(_, name)| VideoCodec::from_rtpmap_name(name) == Some(*vc))
+                .map(|(pt, _)| (*vc, *pt as u8))
+        })
+        .collect();
+    let mut sdp = build_offer(ip, audio_port, &audio_common, direction);
+    if video_common.is_empty() {
+        // RFC 3264: reject unsupported media with port 0.
+        sdp.push_str("m=video 0 RTP/AVP 0\r\n");
+    } else {
+        sdp.push_str(&build_video_section(
+            video_port,
+            &video_common,
+            direction,
+            "RTP/AVP",
+            None,
+            None,
+        ));
+    }
+    sdp
 }
 
 #[cfg(test)]
@@ -605,5 +857,357 @@ mod tests {
         assert!(s.ice_ufrag.is_none());
         assert!(s.ice_pwd.is_none());
         assert!(s.media[0].candidates.is_empty());
+    }
+
+    // --- Video SDP tests ---
+
+    #[test]
+    fn build_offer_video_has_two_m_lines() {
+        let sdp = build_offer_video(
+            "10.0.0.1",
+            5004,
+            &[0, 8],
+            5006,
+            &[VideoCodec::H264, VideoCodec::VP8],
+            "sendrecv",
+        );
+        assert!(sdp.contains("m=audio 5004 RTP/AVP 0 8"));
+        assert!(sdp.contains("m=video 5006 RTP/AVP 96 97"));
+    }
+
+    #[test]
+    fn build_offer_video_h264_rtpmap_fmtp() {
+        let sdp = build_offer_video(
+            "10.0.0.1",
+            5004,
+            &[0],
+            5006,
+            &[VideoCodec::H264],
+            "sendrecv",
+        );
+        assert!(sdp.contains("a=rtpmap:96 H264/90000"));
+        assert!(sdp.contains("a=fmtp:96 profile-level-id=42e01f;packetization-mode=1"));
+    }
+
+    #[test]
+    fn build_offer_video_vp8_no_fmtp() {
+        let sdp = build_offer_video("10.0.0.1", 5004, &[0], 5006, &[VideoCodec::VP8], "sendrecv");
+        assert!(sdp.contains("a=rtpmap:97 VP8/90000"));
+        // VP8 has no fmtp
+        assert!(!sdp.contains("a=fmtp:97"));
+    }
+
+    #[test]
+    fn build_offer_video_rtcp_fb() {
+        let sdp = build_offer_video(
+            "10.0.0.1",
+            5004,
+            &[0],
+            5006,
+            &[VideoCodec::H264],
+            "sendrecv",
+        );
+        assert!(sdp.contains("a=rtcp-fb:96 nack\r\n"));
+        assert!(sdp.contains("a=rtcp-fb:96 nack pli"));
+        assert!(sdp.contains("a=rtcp-fb:96 ccm fir"));
+    }
+
+    #[test]
+    fn build_offer_video_direction() {
+        let sdp = build_offer_video(
+            "10.0.0.1",
+            5004,
+            &[0],
+            5006,
+            &[VideoCodec::H264],
+            "sendonly",
+        );
+        // Both audio and video sections should have the direction
+        let sendonly_count = sdp.matches("a=sendonly").count();
+        assert_eq!(sendonly_count, 2);
+    }
+
+    #[test]
+    fn parse_video_offer_two_m_lines() {
+        let sdp = build_offer_video(
+            "10.0.0.1",
+            5004,
+            &[0, 8],
+            5006,
+            &[VideoCodec::H264, VideoCodec::VP8],
+            "sendrecv",
+        );
+        let s = parse(&sdp).unwrap();
+        assert_eq!(s.media.len(), 2);
+        assert_eq!(s.media[0].media_type, "audio");
+        assert_eq!(s.media[0].port, 5004);
+        assert_eq!(s.media[1].media_type, "video");
+        assert_eq!(s.media[1].port, 5006);
+    }
+
+    #[test]
+    fn parse_video_offer_rtpmap() {
+        let sdp = build_offer_video(
+            "10.0.0.1",
+            5004,
+            &[0],
+            5006,
+            &[VideoCodec::H264, VideoCodec::VP8],
+            "sendrecv",
+        );
+        let s = parse(&sdp).unwrap();
+        let video = s.video_media().unwrap();
+        assert_eq!(video.codecs, vec![96, 97]);
+        assert!(video
+            .rtpmap
+            .iter()
+            .any(|(pt, n)| *pt == 96 && n == "H264/90000"));
+        assert!(video
+            .rtpmap
+            .iter()
+            .any(|(pt, n)| *pt == 97 && n == "VP8/90000"));
+    }
+
+    #[test]
+    fn parse_video_offer_fmtp() {
+        let sdp = build_offer_video(
+            "10.0.0.1",
+            5004,
+            &[0],
+            5006,
+            &[VideoCodec::H264],
+            "sendrecv",
+        );
+        let s = parse(&sdp).unwrap();
+        let video = s.video_media().unwrap();
+        assert!(video
+            .fmtp
+            .iter()
+            .any(|(pt, p)| *pt == 96 && p.contains("profile-level-id")));
+    }
+
+    #[test]
+    fn parse_video_offer_rtcp_fb() {
+        let sdp = build_offer_video(
+            "10.0.0.1",
+            5004,
+            &[0],
+            5006,
+            &[VideoCodec::H264],
+            "sendrecv",
+        );
+        let s = parse(&sdp).unwrap();
+        let video = s.video_media().unwrap();
+        assert!(video
+            .rtcp_fb
+            .iter()
+            .any(|(pt, fb)| *pt == 96 && fb == "nack"));
+        assert!(video
+            .rtcp_fb
+            .iter()
+            .any(|(pt, fb)| *pt == 96 && fb == "nack pli"));
+        assert!(video
+            .rtcp_fb
+            .iter()
+            .any(|(pt, fb)| *pt == 96 && fb == "ccm fir"));
+    }
+
+    #[test]
+    fn session_has_video() {
+        let sdp = build_offer_video(
+            "10.0.0.1",
+            5004,
+            &[0],
+            5006,
+            &[VideoCodec::H264],
+            "sendrecv",
+        );
+        let s = parse(&sdp).unwrap();
+        assert!(s.has_video());
+        assert_eq!(s.video_codec(), Some(VideoCodec::H264));
+    }
+
+    #[test]
+    fn session_audio_only_no_video() {
+        let sdp = build_offer("10.0.0.1", 5004, &[0], "sendrecv");
+        let s = parse(&sdp).unwrap();
+        assert!(!s.has_video());
+        assert_eq!(s.video_codec(), None);
+        assert!(s.audio_media().is_some());
+        assert_eq!(s.audio_media().unwrap().media_type, "audio");
+    }
+
+    #[test]
+    fn audio_only_backwards_compat() {
+        // Existing audio-only functions still work unchanged.
+        let sdp = build_offer("192.168.1.100", 5004, &[0, 8], "sendrecv");
+        let s = parse(&sdp).unwrap();
+        assert_eq!(s.media.len(), 1);
+        assert_eq!(s.media[0].media_type, "audio");
+        assert_eq!(s.first_codec(), 0);
+        assert_eq!(s.dir(), "sendrecv");
+        assert!(!s.has_video());
+    }
+
+    #[test]
+    fn parse_pt_value_rtpmap() {
+        let (pt, name) = parse_pt_value("96 H264/90000").unwrap();
+        assert_eq!(pt, 96);
+        assert_eq!(name, "H264/90000");
+    }
+
+    #[test]
+    fn parse_pt_value_fmtp() {
+        let (pt, params) = parse_pt_value("96 profile-level-id=42e01f").unwrap();
+        assert_eq!(pt, 96);
+        assert_eq!(params, "profile-level-id=42e01f");
+    }
+
+    #[test]
+    fn parse_pt_value_rtcp_fb() {
+        let (pt, fb) = parse_pt_value("96 nack pli").unwrap();
+        assert_eq!(pt, 96);
+        assert_eq!(fb, "nack pli");
+    }
+
+    #[test]
+    fn parse_pt_value_invalid() {
+        assert!(parse_pt_value("").is_none());
+        assert!(parse_pt_value("notanumber foo").is_none());
+    }
+
+    #[test]
+    fn build_offer_video_srtp_has_savp() {
+        let sdp = build_offer_video_srtp(
+            "10.0.0.1",
+            5004,
+            &[0],
+            5006,
+            &[VideoCodec::H264],
+            "sendrecv",
+            "audiokey123",
+            "videokey456",
+        );
+        assert!(sdp.contains("m=audio 5004 RTP/SAVP"));
+        assert!(sdp.contains("m=video 5006 RTP/SAVP"));
+        assert!(sdp.contains("inline:audiokey123"));
+        assert!(sdp.contains("inline:videokey456"));
+    }
+
+    #[test]
+    fn build_answer_video_intersects() {
+        // Remote offers H264(96) + VP8(97), local prefers [VP8, H264].
+        // Answer should include both in local preference order, using remote's PTs.
+        let sdp = build_answer_video(
+            "10.0.0.1",
+            5004,
+            &[0, 8],
+            &[0, 8, 9],
+            5006,
+            &[VideoCodec::VP8, VideoCodec::H264],
+            &[(96, "H264/90000".into()), (97, "VP8/90000".into())],
+            "sendrecv",
+        );
+        let s = parse(&sdp).unwrap();
+        assert!(s.has_video());
+        let video = s.video_media().unwrap();
+        // VP8 first (local preference), then H264 — using remote's PTs
+        assert_eq!(video.codecs[0], 97); // VP8 at remote's PT 97
+        assert_eq!(video.codecs[1], 96); // H264 at remote's PT 96
+    }
+
+    #[test]
+    fn build_answer_video_uses_remote_pt() {
+        // Remote offers H264 at PT 120 (non-default). Answer must mirror PT 120.
+        let sdp = build_answer_video(
+            "10.0.0.1",
+            5004,
+            &[0],
+            &[0],
+            5006,
+            &[VideoCodec::H264],
+            &[(120, "H264/90000".into())],
+            "sendrecv",
+        );
+        let s = parse(&sdp).unwrap();
+        assert!(s.has_video());
+        let video = s.video_media().unwrap();
+        assert_eq!(video.codecs, vec![120]); // Remote's PT, not default 96
+        assert!(video
+            .rtpmap
+            .iter()
+            .any(|(pt, n)| *pt == 120 && n == "H264/90000"));
+    }
+
+    #[test]
+    fn build_answer_video_no_common_rejects_with_port_zero() {
+        // Remote offers only H264, local only supports VP8.
+        // RFC 3264: must include m= line with port 0 to reject.
+        let sdp = build_answer_video(
+            "10.0.0.1",
+            5004,
+            &[0],
+            &[0],
+            5006,
+            &[VideoCodec::VP8],
+            &[(96, "H264/90000".into())],
+            "sendrecv",
+        );
+        let s = parse(&sdp).unwrap();
+        // Video rejected but m= line preserved with port 0.
+        assert_eq!(s.media.len(), 2);
+        assert_eq!(s.media[1].media_type, "video");
+        assert_eq!(s.media[1].port, 0);
+    }
+
+    #[test]
+    fn parse_external_video_sdp() {
+        // Simulate parsing an SDP from a remote endpoint.
+        let raw = "v=0\r\n\
+            o=remote 123 456 IN IP4 203.0.113.1\r\n\
+            s=-\r\n\
+            c=IN IP4 203.0.113.1\r\n\
+            t=0 0\r\n\
+            m=audio 20000 RTP/AVP 0 8\r\n\
+            a=rtpmap:0 PCMU/8000\r\n\
+            a=rtpmap:8 PCMA/8000\r\n\
+            a=sendrecv\r\n\
+            m=video 20002 RTP/AVP 96\r\n\
+            a=rtpmap:96 H264/90000\r\n\
+            a=fmtp:96 profile-level-id=42e01f;packetization-mode=1\r\n\
+            a=rtcp-fb:96 nack\r\n\
+            a=rtcp-fb:96 nack pli\r\n\
+            a=rtcp-fb:96 ccm fir\r\n\
+            a=sendrecv\r\n";
+        let s = parse(raw).unwrap();
+        assert_eq!(s.media.len(), 2);
+        assert_eq!(s.media[0].media_type, "audio");
+        assert_eq!(s.media[0].port, 20000);
+        assert_eq!(s.media[1].media_type, "video");
+        assert_eq!(s.media[1].port, 20002);
+        assert!(s.has_video());
+        assert_eq!(s.video_codec(), Some(VideoCodec::H264));
+
+        let video = s.video_media().unwrap();
+        assert_eq!(video.codecs, vec![96]);
+        assert_eq!(video.rtpmap.len(), 1);
+        assert_eq!(video.fmtp.len(), 1);
+        assert_eq!(video.rtcp_fb.len(), 3);
+    }
+
+    #[test]
+    fn parse_audio_rtpmap_stored() {
+        // Verify rtpmap is also parsed for audio m= lines.
+        let sdp = build_offer("10.0.0.1", 5004, &[0, 8], "sendrecv");
+        let s = parse(&sdp).unwrap();
+        let audio = s.audio_media().unwrap();
+        assert!(audio
+            .rtpmap
+            .iter()
+            .any(|(pt, n)| *pt == 0 && n == "PCMU/8000"));
+        assert!(audio
+            .rtpmap
+            .iter()
+            .any(|(pt, n)| *pt == 8 && n == "PCMA/8000"));
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -357,6 +357,74 @@ fn parse_param(params: &str, name: &str) -> Option<String> {
     None
 }
 
+/// Video codec for SDP negotiation and RTP packetization.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum VideoCodec {
+    /// H.264 / AVC (RFC 6184).
+    H264,
+    /// VP8 (RFC 7741).
+    VP8,
+}
+
+impl VideoCodec {
+    /// Default dynamic RTP payload type used in SDP offers.
+    pub fn default_payload_type(self) -> u8 {
+        match self {
+            VideoCodec::H264 => 96,
+            VideoCodec::VP8 => 97,
+        }
+    }
+
+    /// RTP clock rate (always 90 kHz for video).
+    pub fn clock_rate(self) -> u32 {
+        90000
+    }
+
+    /// SDP rtpmap encoding name (e.g. `"H264/90000"`).
+    pub fn rtpmap_name(self) -> &'static str {
+        match self {
+            VideoCodec::H264 => "H264/90000",
+            VideoCodec::VP8 => "VP8/90000",
+        }
+    }
+
+    /// SDP fmtp parameters, if any.
+    pub fn fmtp(self) -> Option<&'static str> {
+        match self {
+            VideoCodec::H264 => Some("profile-level-id=42e01f;packetization-mode=1"),
+            VideoCodec::VP8 => None,
+        }
+    }
+
+    /// RTCP feedback types for this codec.
+    pub fn rtcp_fb(self) -> &'static [&'static str] {
+        match self {
+            VideoCodec::H264 | VideoCodec::VP8 => &["nack", "nack pli", "ccm fir"],
+        }
+    }
+
+    /// Attempts to identify a video codec from an rtpmap encoding name.
+    pub fn from_rtpmap_name(name: &str) -> Option<VideoCodec> {
+        let codec_part = name.split('/').next()?;
+        if codec_part.eq_ignore_ascii_case("H264") {
+            Some(VideoCodec::H264)
+        } else if codec_part.eq_ignore_ascii_case("VP8") {
+            Some(VideoCodec::VP8)
+        } else {
+            None
+        }
+    }
+}
+
+impl fmt::Display for VideoCodec {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            VideoCodec::H264 => write!(f, "H264"),
+            VideoCodec::VP8 => write!(f, "VP8"),
+        }
+    }
+}
+
 /// Audio codec identified by RTP payload type.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum Codec {
@@ -617,6 +685,68 @@ mod tests {
             .to_string(),
             "terminated;reason=timeout"
         );
+    }
+
+    #[test]
+    fn video_codec_display() {
+        assert_eq!(VideoCodec::H264.to_string(), "H264");
+        assert_eq!(VideoCodec::VP8.to_string(), "VP8");
+    }
+
+    #[test]
+    fn video_codec_default_payload_type() {
+        assert_eq!(VideoCodec::H264.default_payload_type(), 96);
+        assert_eq!(VideoCodec::VP8.default_payload_type(), 97);
+    }
+
+    #[test]
+    fn video_codec_clock_rate() {
+        assert_eq!(VideoCodec::H264.clock_rate(), 90000);
+        assert_eq!(VideoCodec::VP8.clock_rate(), 90000);
+    }
+
+    #[test]
+    fn video_codec_rtpmap_name() {
+        assert_eq!(VideoCodec::H264.rtpmap_name(), "H264/90000");
+        assert_eq!(VideoCodec::VP8.rtpmap_name(), "VP8/90000");
+    }
+
+    #[test]
+    fn video_codec_fmtp() {
+        assert!(VideoCodec::H264
+            .fmtp()
+            .unwrap()
+            .contains("profile-level-id"));
+        assert!(VideoCodec::H264
+            .fmtp()
+            .unwrap()
+            .contains("packetization-mode=1"));
+        assert!(VideoCodec::VP8.fmtp().is_none());
+    }
+
+    #[test]
+    fn video_codec_rtcp_fb() {
+        let fb = VideoCodec::H264.rtcp_fb();
+        assert!(fb.contains(&"nack"));
+        assert!(fb.contains(&"nack pli"));
+        assert!(fb.contains(&"ccm fir"));
+    }
+
+    #[test]
+    fn video_codec_from_rtpmap_name() {
+        assert_eq!(
+            VideoCodec::from_rtpmap_name("H264/90000"),
+            Some(VideoCodec::H264)
+        );
+        assert_eq!(
+            VideoCodec::from_rtpmap_name("VP8/90000"),
+            Some(VideoCodec::VP8)
+        );
+        assert_eq!(
+            VideoCodec::from_rtpmap_name("h264/90000"),
+            Some(VideoCodec::H264)
+        );
+        assert_eq!(VideoCodec::from_rtpmap_name("PCMU/8000"), None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add `VideoCodec` enum (H264, VP8) with dynamic PT mappings, rtpmap/fmtp/rtcp-fb metadata
- Extend SDP building to emit `m=video` lines with `a=rtpmap`, `a=fmtp`, `a=rtcp-fb` attributes
- Extend SDP parser to extract `media_type`, `rtpmap`, `fmtp`, `rtcp_fb` from multiple m= sections
- Add `build_answer_video()` with RFC 3264-compliant PT mirroring and port-0 rejection
- Add `video`/`video_codecs` fields to `DialOptions`
- No video flowing yet — audio behavior completely unchanged

## Test plan
- [x] 35 new/updated tests covering video SDP offer/answer/parsing
- [x] All 635 existing tests pass unchanged (backwards compat verified)
- [x] `cargo fmt && cargo clippy -- -D warnings && cargo test` clean