### PR TITLE
Release v0.3.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2669,7 +2669,7 @@ checksum = "3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f"
 
 [[package]]
 name = "xphone"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "aes",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xphone"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 rust-version = "1.87"
 description = "SIP telephony library with event-driven API — handles SIP signaling, RTP media, codecs, and call state"


### PR DESCRIPTION
## Summary

- Add paced PCM writer (`Call::paced_pcm_writer()`) for TTS/burst audio sources — fixes audio playing at 10x+ speed when providers like Deepgram deliver entire utterances in bursts
- Extract shared `encode_and_send_pcm()` helper (DRY)
- Mutual exclusion between `pcm_writer` and `paced_pcm_writer`
- 8 new tests (710 total)