### PR TITLE
Release v0.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [Unreleased]
+## [0.3.3] - 2026-03-12
 
 ### Changed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xphone"
-version = "0.3.2"
+version = "0.3.3"
 edition = "2021"
 rust-version = "1.87"
 description = "SIP telephony library with event-driven API — handles SIP signaling, RTP media, codecs, and call state"


### PR DESCRIPTION
## Summary
- Bump version to 0.3.3
- `Call::set_rtp_socket` and `Call::set_local_media` are now public API (from PR #27)

## Test plan
- [x] No code changes — version bump and changelog only