### PR TITLE
Release v0.4.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [Unreleased]
+## [0.4.8] - 2026-04-08
 
 ### Added
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2669,7 +2669,7 @@ checksum = "3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f"
 
 [[package]]
 name = "xphone"
-version = "0.4.7"
+version = "0.4.8"
 dependencies = [
  "aes",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xphone"
-version = "0.4.7"
+version = "0.4.8"
 edition = "2021"
 rust-version = "1.87"
 description = "SIP telephony library with event-driven API — handles SIP signaling, RTP media, codecs, and call state"

--- a/README.md
+++ b/README.md
@@ -327,6 +327,7 @@ fn pcm_to_f32(frame: &[i16]) -> Vec<f32> {
 - Early media (183 Session Progress)
 - Outbound proxy routing (`Config::outbound_proxy`)
 - Separate outbound credentials (`outbound_username` / `outbound_password`)
+- Per-call auth credentials (`DialOptions::auth`) for multi-trunk proxy auth
 - P-Asserted-Identity for caller ID (`DialOptions::caller_id`)
 - Custom headers on outbound INVITEs (`DialOptions::custom_headers`)
 - `Server::dial_uri` — dial arbitrary SIP URIs without pre-configured peers


### PR DESCRIPTION
## Summary

- Bump version to 0.4.8
- Per-call SIP auth credentials (`DialOptions::auth`) for multi-trunk proxy auth (xphone-go#90)

## Changelog

### Added

- **Per-call SIP auth credentials** — `DialOptions::auth` (`Option<Credentials>`) overrides config-level `outbound_username` / `outbound_password` for a single outbound call. Enables dialing through multiple SIP trunks with distinct proxy auth without creating separate `Phone` instances. Also available via `DialOptionsBuilder::auth("user", "pass")`. `Credentials` is now re-exported from the crate root.

## Test plan

- [x] `cargo fmt && cargo clippy -- -D warnings && cargo test` — 848 tests pass