### PR TITLE
Add Config::auth_username for separate REGISTER digest identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - **NAT-friendly Via (`;rport`, RFC 3581)** — `Config.nat` / `PhoneBuilder::with_nat(true)` appends `;rport` to outgoing SIP `Via` headers so the server sends responses back to the source IP/port it actually observed. Opt-in (default `false`); harmless on servers that don't understand the parameter. Covers every outbound request path (REGISTER, INVITE, ACK, BYE, SUBSCRIBE, MESSAGE, etc.) and the `TransactionManager` fallback. (xphone-go issue A)
+- **Separate digest auth username for REGISTER** — `Config.auth_username` / `PhoneBuilder::auth_username()` decouples the SIP AOR from the digest `username` parameter. The REGISTER Request-URI, From, To, and Contact still use `Config.username`; only the digest credentials switch to `auth_username`. Enables registering `sip:<aor>@host` while authenticating as a shared trunk auth-user. Falls back to `username` when unset (no behavior change for existing callers).
 
 ### Changed
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -24,6 +24,12 @@ pub struct Config {
     pub username: String,
     /// SIP password for digest authentication.
     pub password: String,
+    /// Digest `username` sent in the REGISTER `Authorization` header.
+    /// Falls back to [`username`](Self::username) when `None` or empty. Allows
+    /// registering the SIP URI `sip:<username>@host` while authenticating as a
+    /// different identity (e.g. a shared trunk auth-user). Does not affect
+    /// INVITE — see [`outbound_username`](Self::outbound_username) for that.
+    pub auth_username: Option<String>,
     /// SIP server hostname or IP address.
     pub host: String,
     /// SIP server port (default `5060`).
@@ -120,6 +126,7 @@ impl Default for Config {
         Config {
             username: String::new(),
             password: String::new(),
+            auth_username: None,
             host: String::new(),
             port: 5060,
             transport: "udp".into(),
@@ -381,6 +388,14 @@ impl PhoneBuilder {
     pub fn outbound_credentials(mut self, username: &str, password: &str) -> Self {
         self.config.outbound_username = Some(username.into());
         self.config.outbound_password = Some(password.into());
+        self
+    }
+
+    /// Sets a digest auth username for REGISTER, decoupled from the SIP AOR.
+    /// The REGISTER Request-URI, From, To, and Contact still use the configured
+    /// [`username`](Config::username); only the digest `username` parameter changes.
+    pub fn auth_username(mut self, auth_username: &str) -> Self {
+        self.config.auth_username = Some(auth_username.into());
         self
     }
 
@@ -665,6 +680,33 @@ mod tests {
         assert_eq!(cfg.media_timeout, Duration::from_secs(60));
         assert_eq!(cfg.nat_keepalive_interval, Some(Duration::from_secs(30)));
         assert_eq!(cfg.pcm_rate, 16000);
+    }
+
+    #[test]
+    fn phone_builder_auth_username() {
+        let cfg = PhoneBuilder::new()
+            .credentials("1003", "pw", "pbx.local")
+            .auth_username("trunk-auth-user")
+            .build();
+        assert_eq!(cfg.username, "1003");
+        assert_eq!(cfg.auth_username.as_deref(), Some("trunk-auth-user"));
+    }
+
+    #[test]
+    fn auth_username_defaults_to_none() {
+        let cfg = Config::default();
+        assert!(cfg.auth_username.is_none());
+    }
+
+    #[test]
+    fn phone_builder_auth_username_empty_string_kept_on_config() {
+        // Builder stores the string as-is; the client-level helper treats
+        // empty as equivalent to unset (see client::register_auth_username).
+        let cfg = PhoneBuilder::new()
+            .credentials("1003", "pw", "pbx.local")
+            .auth_username("")
+            .build();
+        assert_eq!(cfg.auth_username.as_deref(), Some(""));
     }
 
     #[test]

--- a/src/sip/client.rs
+++ b/src/sip/client.rs
@@ -43,6 +43,8 @@ pub struct ClientConfig {
     pub server_addr: SocketAddr,
     pub username: String,
     pub password: String,
+    /// Digest `username` for REGISTER. Falls back to `username` if `None`.
+    pub auth_username: Option<String>,
     pub domain: String,
     /// Transport protocol: "udp", "tcp", or "tls".
     pub transport: String,
@@ -69,6 +71,7 @@ impl Default for ClientConfig {
             server_addr: "127.0.0.1:5060".parse().unwrap(),
             username: String::new(),
             password: String::new(),
+            auth_username: None,
             domain: String::new(),
             transport: "udp".into(),
             tls_config: None,
@@ -239,7 +242,7 @@ impl Client {
                 Err(_) => return Ok((401, auth_hdr.to_string())),
             };
             let creds = Credentials {
-                username: self.cfg.username.clone(),
+                username: self.register_auth_username().to_string(),
                 password: self.cfg.password.clone(),
             };
             let auth_val = auth::build_authorization(&ch, &creds, "REGISTER", &request_uri);
@@ -284,7 +287,7 @@ impl Client {
                 Err(_) => return Ok((401, auth_hdr.to_string())),
             };
             let creds = Credentials {
-                username: self.cfg.username.clone(),
+                username: self.register_auth_username().to_string(),
                 password: self.cfg.password.clone(),
             };
             let auth_val = auth::build_authorization(&ch, &creds, "REGISTER", &request_uri);
@@ -333,6 +336,16 @@ impl Client {
             "SIP/2.0/{} {};branch={}{}",
             self.via_transport, addr, branch, rport
         )
+    }
+
+    /// Digest `username` for REGISTER. Falls back to the AOR username when
+    /// `auth_username` is `None` or an empty string (matches xphone-go behavior).
+    fn register_auth_username(&self) -> &str {
+        self.cfg
+            .auth_username
+            .as_deref()
+            .filter(|s| !s.is_empty())
+            .unwrap_or(&self.cfg.username)
     }
 
     /// Returns the username for outbound INVITE auth (falls back to main credentials).
@@ -1074,6 +1087,151 @@ mod tests {
 
         client.close();
         handle.join().unwrap();
+    }
+
+    #[test]
+    fn register_uses_auth_username_for_digest_only() {
+        // REGISTER digest must use auth_username; From/To/Contact still use username.
+        let server = UdpConn::bind("127.0.0.1:0").unwrap();
+        let server_addr = server.local_addr().unwrap();
+
+        let cfg = ClientConfig {
+            local_addr: "127.0.0.1:0".into(),
+            server_addr,
+            username: "1003".into(),
+            password: "secret".into(),
+            auth_username: Some("trunk-auth-user".into()),
+            domain: "pbx.local".into(),
+            ..Default::default()
+        };
+        let client = Client::new(cfg).unwrap();
+
+        let handle = std::thread::spawn(move || {
+            // First request → 401.
+            let (data, from) = server.receive(Duration::from_secs(2)).unwrap();
+            let req = super::super::message::parse(&data).unwrap();
+            assert!(
+                req.header("From").contains("sip:1003@"),
+                "From must use AOR username, got: {}",
+                req.header("From")
+            );
+            assert!(
+                req.header("To").contains("sip:1003@"),
+                "To must use AOR username, got: {}",
+                req.header("To")
+            );
+            assert!(
+                req.header("Contact").contains("sip:1003@"),
+                "Contact must use AOR username, got: {}",
+                req.header("Contact")
+            );
+
+            let mut resp = Message::new_response(401, "Unauthorized");
+            resp.set_header("Via", req.header("Via"));
+            resp.set_header("Call-ID", req.header("Call-ID"));
+            resp.set_header("CSeq", req.header("CSeq"));
+            resp.set_header(
+                "WWW-Authenticate",
+                r#"Digest realm="asterisk",nonce="abc123",algorithm=MD5"#,
+            );
+            server.send(&resp.to_bytes(), from).unwrap();
+
+            // Second request — digest username must be auth_username, not AOR.
+            let (data, from) = server.receive(Duration::from_secs(2)).unwrap();
+            let req = super::super::message::parse(&data).unwrap();
+            let auth = req.header("Authorization");
+            assert!(
+                auth.contains(r#"username="trunk-auth-user""#),
+                "expected digest username=trunk-auth-user, got: {auth}"
+            );
+            assert!(
+                !auth.contains(r#"username="1003""#),
+                "digest must not use AOR username, got: {auth}"
+            );
+            assert!(
+                req.header("From").contains("sip:1003@"),
+                "From must still use AOR username on retry, got: {}",
+                req.header("From")
+            );
+            assert!(
+                req.header("Contact").contains("sip:1003@"),
+                "Contact must still use AOR username on retry, got: {}",
+                req.header("Contact")
+            );
+
+            let mut resp = Message::new_response(200, "OK");
+            resp.set_header("Via", req.header("Via"));
+            resp.set_header("Call-ID", req.header("Call-ID"));
+            resp.set_header("CSeq", req.header("CSeq"));
+            server.send(&resp.to_bytes(), from).unwrap();
+        });
+
+        let (code, _) = client.send_register(Duration::from_secs(5)).unwrap();
+        assert_eq!(code, 200);
+        client.close();
+        handle.join().unwrap();
+    }
+
+    #[test]
+    fn register_falls_back_to_username_when_auth_username_unset() {
+        // Default behavior: digest username equals AOR username.
+        let server = UdpConn::bind("127.0.0.1:0").unwrap();
+        let server_addr = server.local_addr().unwrap();
+
+        let cfg = ClientConfig {
+            local_addr: "127.0.0.1:0".into(),
+            server_addr,
+            username: "1003".into(),
+            password: "secret".into(),
+            domain: "pbx.local".into(),
+            ..Default::default()
+        };
+        let client = Client::new(cfg).unwrap();
+
+        let handle = std::thread::spawn(move || {
+            let (data, from) = server.receive(Duration::from_secs(2)).unwrap();
+            let req = super::super::message::parse(&data).unwrap();
+            let mut resp = Message::new_response(401, "Unauthorized");
+            resp.set_header("Via", req.header("Via"));
+            resp.set_header("Call-ID", req.header("Call-ID"));
+            resp.set_header("CSeq", req.header("CSeq"));
+            resp.set_header(
+                "WWW-Authenticate",
+                r#"Digest realm="asterisk",nonce="abc123",algorithm=MD5"#,
+            );
+            server.send(&resp.to_bytes(), from).unwrap();
+
+            let (data, from) = server.receive(Duration::from_secs(2)).unwrap();
+            let req = super::super::message::parse(&data).unwrap();
+            let auth = req.header("Authorization");
+            assert!(
+                auth.contains(r#"username="1003""#),
+                "expected digest username=1003 fallback, got: {auth}"
+            );
+
+            let mut resp = Message::new_response(200, "OK");
+            resp.set_header("Via", req.header("Via"));
+            resp.set_header("Call-ID", req.header("Call-ID"));
+            resp.set_header("CSeq", req.header("CSeq"));
+            server.send(&resp.to_bytes(), from).unwrap();
+        });
+
+        let (code, _) = client.send_register(Duration::from_secs(5)).unwrap();
+        assert_eq!(code, 200);
+        client.close();
+        handle.join().unwrap();
+    }
+
+    #[test]
+    fn register_auth_username_empty_string_falls_back_to_aor() {
+        let cfg = ClientConfig {
+            username: "1003".into(),
+            auth_username: Some(String::new()),
+            ..Default::default()
+        };
+        let client = Client::new(cfg).unwrap();
+        assert_eq!(client.register_auth_username(), "1003");
+        client.close();
     }
 
     #[test]

--- a/src/sip/ua.rs
+++ b/src/sip/ua.rs
@@ -84,6 +84,7 @@ impl SipUA {
             server_addr,
             username: cfg.username.clone(),
             password: cfg.password.clone(),
+            auth_username: cfg.auth_username.clone(),
             domain: cfg.host.clone(),
             transport: transport.clone(),
             tls_config: cfg.tls_config.clone(),


### PR DESCRIPTION
## Summary

Adds `Config::auth_username: Option<String>` so the SIP AOR can be decoupled from the digest `username` used in REGISTER authentication. Mirrors the `Config.AuthUsername` change being made in xphone-go.

## Motivation

Previously, `cfg.username` was used both to build the REGISTER Request-URI / From / To / Contact **and** as the digest `username`. That ties the registered SIP identity to the auth identity — you couldn't register `sip:1003@trunk.example.com` while digest-authing as a shared trunk user (e.g. `9AkZWSyauG`).

INVITE already supports this separation via `outbound_username` / `DialOptions::auth`. This PR brings REGISTER to parity.

## Scope

- REGISTER only. Does **not** touch INVITE (already handled), SUBSCRIBE, or MESSAGE.
- From/To/Contact/Request-URI on REGISTER are unchanged — they still use the AOR `username`.
- Only the digest `username` parameter in the `Authorization` header switches to `auth_username` when set.

## Fallback rules

`auth_username` falls back to `username` when `None` **or empty** (matches the Go fix's "default to Username if empty"). No behavior change for existing callers who never set the field.

## Tests

- `register_uses_auth_username_for_digest_only` — verifies digest `username=` uses `auth_username` while From/To/Contact keep the AOR on both initial and authenticated REGISTER.
- `register_falls_back_to_username_when_auth_username_unset` — default path unchanged.
- `register_auth_username_empty_string_falls_back_to_aor` — empty-string treated as unset.
- `phone_builder_auth_username` — builder plumbing.

## API addition

```rust
let cfg = PhoneBuilder::new()
    .credentials("1003", "pw", "pbx.local")
    .auth_username("trunk-auth-user")  // NEW
    .build();
```