### PR TITLE
Config::nat (rport) + detailed Error::RegistrationFailed (v0.5.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 - **BREAKING: `Error::RegistrationFailed` now carries `{ code: u16, reason: String }`** — the last SIP status and reason-phrase observed across retry attempts are surfaced on the returned error and passed to `on_error` callbacks. `code == 0` means no SIP response was received (pure transport failure) and `reason` describes the transport error. The final `warn!` on retry exhaustion also logs `last_code` and `last_reason`. Callers pattern-matching `Error::RegistrationFailed` must update to the struct form. (xphone-go#96)
+- **`Config.outbound_proxy` now routes all outbound SIP requests**, not just INVITE. REGISTER, SUBSCRIBE, MESSAGE, in-dialog sends (BYE, re-INVITE, REFER, INFO), ACK, and NAT keep-alives now target the proxy when set; previously only INVITE did. For TCP/TLS the transport connection also targets the proxy. Matches how Kamailio / OpenSIPS / Asterisk outbound-proxy deployments actually work. No change when `outbound_proxy` is unset. Behavior change for anyone who was setting `outbound_proxy` and relying on REGISTER bypassing it — if you need separate routing, file an issue requesting `registrar_proxy`. (xphone-go outbound-proxy issue)
 
 ## [0.4.8] - 2026-04-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Added
+
+- **NAT-friendly Via (`;rport`, RFC 3581)** — `Config.nat` / `PhoneBuilder::with_nat(true)` appends `;rport` to outgoing SIP `Via` headers so the server sends responses back to the source IP/port it actually observed. Opt-in (default `false`); harmless on servers that don't understand the parameter. Covers every outbound request path (REGISTER, INVITE, ACK, BYE, SUBSCRIBE, MESSAGE, etc.) and the `TransactionManager` fallback. (xphone-go issue A)
+
+### Changed
+
+- **BREAKING: `Error::RegistrationFailed` now carries `{ code: u16, reason: String }`** — the last SIP status and reason-phrase observed across retry attempts are surfaced on the returned error and passed to `on_error` callbacks. `code == 0` means no SIP response was received (pure transport failure) and `reason` describes the transport error. The final `warn!` on retry exhaustion also logs `last_code` and `last_reason`. Callers pattern-matching `Error::RegistrationFailed` must update to the struct form. (xphone-go#96)
+
 ## [0.4.8] - 2026-04-08
 
 ### Added

--- a/src/call.rs
+++ b/src/call.rs
@@ -1319,24 +1319,21 @@ impl Call {
                     }
                     false
                 }
-                200 => {
-                    if inner.state == CallState::Dialing
-                        || inner.state == CallState::RemoteRinging
-                        || inner.state == CallState::EarlyMedia
-                    {
-                        inner.state = CallState::Active;
-                        inner.start_time = Some(Instant::now());
-                        inner.media_active = true;
-                        Self::start_media_pipeline(&mut inner);
-                        Self::fire_on_state(&inner, CallState::Active);
-                        for f in &inner.on_media_fn {
-                            let f = Arc::clone(f);
-                            spawn_callback(move || f());
-                        }
-                        true
-                    } else {
-                        false
+                200 if matches!(
+                    inner.state,
+                    CallState::Dialing | CallState::RemoteRinging | CallState::EarlyMedia
+                ) =>
+                {
+                    inner.state = CallState::Active;
+                    inner.start_time = Some(Instant::now());
+                    inner.media_active = true;
+                    Self::start_media_pipeline(&mut inner);
+                    Self::fire_on_state(&inner, CallState::Active);
+                    for f in &inner.on_media_fn {
+                        let f = Arc::clone(f);
+                        spawn_callback(move || f());
                     }
+                    true
                 }
                 _ => false,
             };

--- a/src/config.rs
+++ b/src/config.rs
@@ -43,6 +43,13 @@ pub struct Config {
     /// Interval for NAT keep-alive packets. `None` disables keep-alive.
     pub nat_keepalive_interval: Option<Duration>,
 
+    /// Enable NAT-friendly SIP transport behaviour. When `true`, outgoing
+    /// Via headers include the `;rport` parameter (RFC 3581) so the server
+    /// sends responses to the source IP/port the request actually arrived
+    /// from. Harmless on servers that don't understand it. Opt-in so
+    /// existing deployments see no change.
+    pub nat: bool,
+
     /// Override the local IP advertised in SDP/Via/Contact.
     /// If empty, the address is auto-detected.
     pub local_ip: String,
@@ -117,6 +124,7 @@ impl Default for Config {
             register_retry: Duration::from_secs(1),
             register_max_retry: 3,
             nat_keepalive_interval: None,
+            nat: false,
             local_ip: String::new(),
             rtp_port_min: 0,
             rtp_port_max: 0,
@@ -269,6 +277,14 @@ impl PhoneBuilder {
     /// Enables NAT keep-alive with the given interval.
     pub fn nat_keepalive(mut self, d: Duration) -> Self {
         self.config.nat_keepalive_interval = Some(d);
+        self
+    }
+
+    /// Enables NAT-friendly SIP transport: appends `;rport` (RFC 3581) to
+    /// outgoing Via headers so responses are routed back to the source IP/port
+    /// observed by the server. Default is off.
+    pub fn with_nat(mut self, enabled: bool) -> Self {
+        self.config.nat = enabled;
         self
     }
 
@@ -653,6 +669,21 @@ mod tests {
         assert!(opts.caller_id.is_none());
         assert!(opts.custom_headers.is_empty());
         assert!(opts.codec_override.is_empty());
+    }
+
+    #[test]
+    fn nat_default_is_off() {
+        let cfg = Config::default();
+        assert!(!cfg.nat);
+    }
+
+    #[test]
+    fn phone_builder_with_nat_enables_rport() {
+        let cfg = PhoneBuilder::new()
+            .credentials("1001", "pw", "pbx.local")
+            .with_nat(true)
+            .build();
+        assert!(cfg.nat);
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -101,9 +101,13 @@ pub struct Config {
     /// Defaults to `"xphone"`. PBXes use this to identify the device.
     pub user_agent: String,
 
-    /// Outbound proxy URI for routing INVITEs (e.g. `"sip:proxy.example.com:5060"`).
-    /// When set, outbound INVITEs are sent to this proxy instead of the registrar.
-    /// Registration traffic still goes to `host:port`.
+    /// Outbound proxy URI for routing **all** outbound SIP requests
+    /// (e.g. `"sip:proxy.example.com:5060"`). When set, REGISTER, INVITE,
+    /// SUBSCRIBE, MESSAGE, in-dialog requests (BYE, re-INVITE, REFER, INFO),
+    /// ACK, and NAT keep-alives all route through this proxy instead of
+    /// `host:port`. For TCP/TLS, the transport connection also targets the
+    /// proxy. Mirrors how outbound-proxy deployments (Kamailio, OpenSIPS,
+    /// Asterisk) actually behave.
     pub outbound_proxy: Option<String>,
     /// Username for outbound INVITE authentication. Falls back to `username` if unset.
     pub outbound_username: Option<String>,
@@ -363,8 +367,10 @@ impl PhoneBuilder {
         self
     }
 
-    /// Sets an outbound proxy for routing INVITEs (e.g. `"sip:proxy.example.com:5060"`).
-    /// Registration traffic still goes to the configured host.
+    /// Sets an outbound proxy for routing all outbound SIP requests —
+    /// REGISTER, INVITE, SUBSCRIBE, MESSAGE, in-dialog sends, and NAT
+    /// keep-alives (e.g. `"sip:proxy.example.com:5060"`). For TCP/TLS the
+    /// transport connection also targets the proxy.
     pub fn outbound_proxy(mut self, proxy: &str) -> Self {
         self.config.outbound_proxy = Some(proxy.into());
         self

--- a/src/dialog_info.rs
+++ b/src/dialog_info.rs
@@ -92,16 +92,12 @@ pub fn parse_dialog_states(xml: &str) -> Vec<String> {
                     in_state = false;
                 }
             }
-            Ok(Event::Text(e)) => {
-                if in_state {
-                    match e.unescape() {
-                        Ok(text) => states.push(text.trim().to_lowercase()),
-                        Err(err) => {
-                            debug!(error = %err, "dialog-info: failed to unescape state text");
-                        }
-                    }
+            Ok(Event::Text(e)) if in_state => match e.unescape() {
+                Ok(text) => states.push(text.trim().to_lowercase()),
+                Err(err) => {
+                    debug!(error = %err, "dialog-info: failed to unescape state text");
                 }
-            }
+            },
             Ok(Event::Eof) => break,
             Err(err) => {
                 debug!(error = %err, "dialog-info: XML parse error");

--- a/src/error.rs
+++ b/src/error.rs
@@ -19,9 +19,13 @@ pub enum Error {
     /// All ports in the configured RTP port range are in use.
     #[error("xphone: RTP port range exhausted")]
     NoRtpPortAvailable,
-    /// SIP REGISTER request was rejected by the server.
-    #[error("xphone: registration failed")]
-    RegistrationFailed,
+    /// SIP REGISTER request was rejected, or all retries were exhausted.
+    /// `code` is the last SIP status observed across retry attempts (`0` when
+    /// no response was received, e.g. transport failure). `reason` carries the
+    /// corresponding reason-phrase, or a transport error description when
+    /// `code == 0`.
+    #[error("{}", format_registration_failed(*code, reason))]
+    RegistrationFailed { code: u16, reason: String },
     /// SIP REFER (blind transfer) was rejected or failed.
     #[error("xphone: transfer failed")]
     TransferFailed,
@@ -66,6 +70,17 @@ pub enum Error {
 /// Convenience alias for `std::result::Result<T, Error>`.
 pub type Result<T> = std::result::Result<T, Error>;
 
+/// Formats [`Error::RegistrationFailed`] suppressing `code` when it is `0`
+/// (pure transport failure) and suppressing `reason` when empty.
+fn format_registration_failed(code: u16, reason: &str) -> String {
+    match (code, reason.is_empty()) {
+        (0, true) => "xphone: registration failed".into(),
+        (0, false) => format!("xphone: registration failed: {reason}"),
+        (c, true) => format!("xphone: registration failed: {c}"),
+        (c, false) => format!("xphone: registration failed: {c} {reason}"),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -81,6 +96,33 @@ mod tests {
             Error::InvalidDtmfDigit.to_string(),
             "xphone: invalid DTMF digit"
         );
+    }
+
+    #[test]
+    fn registration_failed_display_skips_zero_and_empty() {
+        let full = Error::RegistrationFailed {
+            code: 403,
+            reason: "Forbidden".into(),
+        };
+        assert_eq!(
+            full.to_string(),
+            "xphone: registration failed: 403 Forbidden"
+        );
+
+        let transport = Error::RegistrationFailed {
+            code: 0,
+            reason: "transport: timeout".into(),
+        };
+        assert_eq!(
+            transport.to_string(),
+            "xphone: registration failed: transport: timeout"
+        );
+
+        let bare = Error::RegistrationFailed {
+            code: 0,
+            reason: String::new(),
+        };
+        assert_eq!(bare.to_string(), "xphone: registration failed");
     }
 
     #[test]

--- a/src/mock/phone.rs
+++ b/src/mock/phone.rs
@@ -498,7 +498,10 @@ mod tests {
         p.on_error(move |_| {
             fired_clone.store(true, Ordering::Relaxed);
         });
-        p.simulate_error(Error::RegistrationFailed);
+        p.simulate_error(Error::RegistrationFailed {
+            code: 403,
+            reason: "Forbidden".into(),
+        });
         assert!(fired.load(Ordering::Relaxed));
     }
 

--- a/src/phone.rs
+++ b/src/phone.rs
@@ -51,6 +51,11 @@ struct Inner {
     subscription_mgr: Option<Arc<SubscriptionManager>>,
     /// BLF watchers: extension -> (SubId, last known state).
     blf_watchers: HashMap<String, (SubId, ExtensionState)>,
+
+    /// Last error returned by the registry's initial `start()`. Read by
+    /// [`Phone::connect`] so callers see the real SIP code/reason instead
+    /// of a bare `RegistrationFailed { code: 0, reason: "" }`.
+    last_reg_error: Option<Error>,
 }
 
 /// Phone orchestrates SIP registration, call tracking, and incoming/outgoing calls.
@@ -86,6 +91,7 @@ impl Phone {
                 dtmf_mode,
                 subscription_mgr: None,
                 blf_watchers: HashMap::new(),
+                last_reg_error: None,
             })),
         }
     }
@@ -99,11 +105,15 @@ impl Phone {
         let state = self.state();
         if state == PhoneState::Registered {
             info!("Phone connected and registered");
-            Ok(())
-        } else {
-            warn!("Phone registration failed");
-            Err(crate::error::Error::RegistrationFailed)
+            return Ok(());
         }
+        // Surface the last observed registration error (populated by Registry).
+        let last_err = self.inner.lock().last_reg_error.clone();
+        warn!(err = ?last_err, "Phone registration failed");
+        Err(last_err.unwrap_or(crate::error::Error::RegistrationFailed {
+            code: 0,
+            reason: String::new(),
+        }))
     }
 
     /// Connects with a provided transport (test hook).
@@ -227,10 +237,15 @@ impl Phone {
         inner.reg = Some(reg);
         inner.mwi = mwi;
         inner.subscription_mgr = Some(sub_mgr);
-        if reg_result.is_ok() {
-            inner.state = PhoneState::Registered;
-        } else {
-            inner.state = PhoneState::RegistrationFailed;
+        match reg_result {
+            Ok(()) => {
+                inner.state = PhoneState::Registered;
+                inner.last_reg_error = None;
+            }
+            Err(e) => {
+                inner.state = PhoneState::RegistrationFailed;
+                inner.last_reg_error = Some(e);
+            }
         }
     }
 

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -148,8 +148,13 @@ impl Registry {
     }
 
     /// Sends REGISTER with retries. On success, transitions to Registered and
-    /// fires OnRegistered. On exhausting retries, fires OnError.
+    /// fires OnRegistered. On exhausting retries, fires OnError with the last
+    /// observed SIP status (or `code == 0` and the transport error description
+    /// if no response was received).
     fn register(&self) -> Result<()> {
+        let mut last_code: u16 = 0;
+        let mut last_reason: String = String::new();
+
         for attempt in 0..self.cfg.register_max_retry {
             if attempt > 0 {
                 debug!(attempt, "REGISTER retry after delay");
@@ -165,8 +170,10 @@ impl Registry {
                 .send_request("REGISTER", None, self.cfg.register_expiry);
             let msg = match result {
                 Ok(m) => m,
-                Err(ref e) => {
+                Err(e) => {
                     warn!(attempt, error = %e, "REGISTER failed");
+                    last_code = 0;
+                    last_reason = format!("transport: {}", e);
                     continue;
                 }
             };
@@ -183,11 +190,16 @@ impl Registry {
                 }
                 return Ok(());
             }
+
+            last_code = msg.status_code;
+            last_reason = msg.reason.clone();
         }
 
         // All retries exhausted.
         warn!(
             max_retry = self.cfg.register_max_retry,
+            last_code,
+            last_reason = %last_reason,
             "REGISTER failed — all retries exhausted"
         );
         let cbs = {
@@ -195,11 +207,15 @@ impl Registry {
             inner.state = PhoneState::RegistrationFailed;
             inner.on_error.clone()
         };
+        let err = Error::RegistrationFailed {
+            code: last_code,
+            reason: last_reason.clone(),
+        };
         for f in cbs {
-            let err = Error::RegistrationFailed;
+            let err = err.clone();
             spawn_callback(move || f(err));
         }
-        Err(Error::RegistrationFailed)
+        Err(err)
     }
 }
 
@@ -243,6 +259,9 @@ fn handle_drop(inner: &Arc<Mutex<Inner>>, tr: &Arc<dyn SipTransport>, cfg: &Conf
 
 /// Re-registration attempt after a transport drop.
 fn reregister(inner: &Arc<Mutex<Inner>>, tr: &Arc<dyn SipTransport>, cfg: &Config) -> Result<()> {
+    let mut last_code: u16 = 0;
+    let mut last_reason: String = String::new();
+
     for attempt in 0..cfg.register_max_retry {
         if attempt > 0 {
             if inner.lock().stopped {
@@ -254,7 +273,11 @@ fn reregister(inner: &Arc<Mutex<Inner>>, tr: &Arc<dyn SipTransport>, cfg: &Confi
         let result = tr.send_request("REGISTER", None, cfg.register_expiry);
         let msg = match result {
             Ok(m) => m,
-            Err(_) => continue,
+            Err(e) => {
+                last_code = 0;
+                last_reason = format!("transport: {}", e);
+                continue;
+            }
         };
 
         if msg.status_code == 200 {
@@ -268,18 +291,30 @@ fn reregister(inner: &Arc<Mutex<Inner>>, tr: &Arc<dyn SipTransport>, cfg: &Confi
             }
             return Ok(());
         }
+
+        last_code = msg.status_code;
+        last_reason = msg.reason.clone();
     }
 
+    warn!(
+        last_code,
+        last_reason = %last_reason,
+        "re-REGISTER failed — all retries exhausted"
+    );
     let cbs = {
         let mut guard = inner.lock();
         guard.state = PhoneState::RegistrationFailed;
         guard.on_error.clone()
     };
+    let err = Error::RegistrationFailed {
+        code: last_code,
+        reason: last_reason.clone(),
+    };
     for f in cbs {
-        let err = Error::RegistrationFailed;
+        let err = err.clone();
         spawn_callback(move || f(err));
     }
-    Err(Error::RegistrationFailed)
+    Err(err)
 }
 
 /// Background loop: periodic refresh and NAT keepalive.
@@ -384,6 +419,74 @@ mod tests {
 
         assert!(result.is_err());
         assert_eq!(reg.state(), PhoneState::RegistrationFailed);
+    }
+
+    #[test]
+    fn start_surfaces_403_code_and_reason() {
+        // A SIP rejection (403 Forbidden) on every attempt must surface the
+        // status code and reason-phrase in the returned error.
+        let tr = Arc::new(MockTransport::new());
+        for _ in 0..3 {
+            tr.respond_with(403, "Forbidden");
+        }
+
+        let reg = Registry::new(Arc::clone(&tr) as Arc<dyn SipTransport>, test_cfg());
+        let err = reg.start().unwrap_err();
+
+        match err {
+            Error::RegistrationFailed { code, reason } => {
+                assert_eq!(code, 403);
+                assert_eq!(reason, "Forbidden");
+            }
+            other => panic!("expected RegistrationFailed {{403, Forbidden}}, got {other:?}"),
+        }
+        assert_eq!(reg.state(), PhoneState::RegistrationFailed);
+    }
+
+    #[test]
+    fn start_transport_failure_surfaces_code_zero() {
+        // Pure transport failure (no SIP response ever received) must produce
+        // code=0 with a transport-error reason-phrase.
+        let tr = Arc::new(MockTransport::new());
+        tr.fail_next(10);
+
+        let reg = Registry::new(Arc::clone(&tr) as Arc<dyn SipTransport>, test_cfg());
+        let err = reg.start().unwrap_err();
+
+        match err {
+            Error::RegistrationFailed { code, reason } => {
+                assert_eq!(code, 0, "transport failure must not surface a SIP code");
+                assert!(
+                    reason.starts_with("transport:"),
+                    "reason should describe transport failure, got: {reason}"
+                );
+            }
+            other => panic!("expected RegistrationFailed {{0, transport:...}}, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn start_error_callback_receives_detailed_error() {
+        let tr = Arc::new(MockTransport::new());
+        for _ in 0..3 {
+            tr.respond_with(503, "Service Unavailable");
+        }
+
+        let reg = Registry::new(Arc::clone(&tr) as Arc<dyn SipTransport>, test_cfg());
+        let (tx, rx) = crossbeam_channel::bounded(1);
+        reg.on_error(move |e| {
+            let _ = tx.send(e);
+        });
+
+        let _ = reg.start();
+        let received = rx.recv_timeout(Duration::from_secs(2)).unwrap();
+        match received {
+            Error::RegistrationFailed { code, reason } => {
+                assert_eq!(code, 503);
+                assert_eq!(reason, "Service Unavailable");
+            }
+            other => panic!("expected detailed RegistrationFailed, got {other:?}"),
+        }
     }
 
     #[test]

--- a/src/sip/client.rs
+++ b/src/sip/client.rs
@@ -99,9 +99,13 @@ pub struct Client {
 impl Client {
     /// Creates a new SIP client, binding or connecting based on transport.
     pub fn new(cfg: ClientConfig) -> Result<Self> {
+        // Use the outbound proxy as the transport peer when set. For TCP/TLS
+        // this is load-bearing: the connection is established once, and
+        // `send`'s destination argument is ignored by the stream.
+        let transport_peer = cfg.outbound_proxy.unwrap_or(cfg.server_addr);
         let sip_conn = conn::connect(
             &cfg.transport,
-            cfg.server_addr,
+            transport_peer,
             &cfg.local_addr,
             &cfg.domain,
             cfg.tls_config.as_ref(),
@@ -125,9 +129,10 @@ impl Client {
                 SocketAddr::new(stun_addr.ip(), local_addr.port())
             } else {
                 // Fallback: UDP connect trick to determine local routable IP.
+                // Probe the actual next-hop (outbound proxy if set).
                 use std::net::UdpSocket;
                 match UdpSocket::bind("0.0.0.0:0") {
-                    Ok(sock) => match sock.connect(cfg.server_addr) {
+                    Ok(sock) => match sock.connect(transport_peer) {
                         Ok(()) => match sock.local_addr() {
                             Ok(addr) if !addr.ip().is_unspecified() => {
                                 SocketAddr::new(addr.ip(), local_addr.port())
@@ -219,8 +224,9 @@ impl Client {
         let request_uri = format!("sip:{}", self.cfg.domain);
         let mut req = self.build_request("REGISTER", &request_uri, None);
 
-        debug!(method = "REGISTER", uri = %request_uri, server = %self.cfg.server_addr, "SIP >>> sending");
-        let resp = self.tm.send(&mut req, self.cfg.server_addr, timeout)?;
+        let dest = self.outbound_dest();
+        debug!(method = "REGISTER", uri = %request_uri, dest = %dest, "SIP >>> sending");
+        let resp = self.tm.send(&mut req, dest, timeout)?;
         debug!(method = "REGISTER", status = resp.status_code, reason = %resp.reason, "SIP <<< response");
         let branch = req.via_branch().to_string();
 
@@ -242,7 +248,7 @@ impl Client {
             extra.insert("Authorization".to_string(), auth_val);
             let mut retry = self.build_request("REGISTER", &request_uri, Some(&extra));
             debug!(method = "REGISTER", "SIP >>> re-sending with auth");
-            let resp = self.tm.send(&mut retry, self.cfg.server_addr, timeout)?;
+            let resp = self.tm.send(&mut retry, dest, timeout)?;
             info!(method = "REGISTER", status = resp.status_code, reason = %resp.reason, "SIP <<< auth response");
             let retry_branch = retry.via_branch().to_string();
             self.tm.remove_tx(&retry_branch);
@@ -264,8 +270,9 @@ impl Client {
         extra.insert("Expires".to_string(), "0".to_string());
         let mut req = self.build_request("REGISTER", &request_uri, Some(&extra));
 
+        let dest = self.outbound_dest();
         info!("SIP >>> REGISTER Expires=0 (unregister)");
-        let resp = self.tm.send(&mut req, self.cfg.server_addr, timeout)?;
+        let resp = self.tm.send(&mut req, dest, timeout)?;
         let branch = req.via_branch().to_string();
 
         // Handle 401 auth challenge.
@@ -286,7 +293,7 @@ impl Client {
             extra2.insert("Authorization".to_string(), auth_val);
             extra2.insert("Expires".to_string(), "0".to_string());
             let mut retry = self.build_request("REGISTER", &request_uri, Some(&extra2));
-            let resp = self.tm.send(&mut retry, self.cfg.server_addr, timeout)?;
+            let resp = self.tm.send(&mut retry, dest, timeout)?;
             info!(status = resp.status_code, "SIP <<< unregister response");
             let retry_branch = retry.via_branch().to_string();
             self.tm.remove_tx(&retry_branch);
@@ -487,7 +494,7 @@ impl Client {
             // Send ACK for 2xx.
             let ack = self.build_ack(&invite, &resp);
             self.tm.remove_tx(branch);
-            self.tm.send_raw(&ack.to_bytes(), self.cfg.server_addr)?;
+            self.tm.send_raw(&ack.to_bytes(), self.outbound_dest())?;
             Ok(ConsumeResult::Success(Box::new(InviteResult {
                 invite,
                 response: resp,
@@ -499,7 +506,7 @@ impl Client {
             // Send ACK for 3xx (required by RFC 3261 §17.1.1.3).
             // Non-2xx ACK reuses the INVITE's Via branch (same transaction).
             let ack = self.build_ack_non2xx(&invite, &resp, branch);
-            if let Err(e) = self.tm.send_raw(&ack.to_bytes(), self.cfg.server_addr) {
+            if let Err(e) = self.tm.send_raw(&ack.to_bytes(), self.outbound_dest()) {
                 warn!(error = %e, "failed to send ACK for 3xx redirect");
             }
             self.tm.remove_tx(branch);
@@ -539,8 +546,9 @@ impl Client {
         // Override To header to target the subscription URI.
         req.set_header("To", &format!("<{}>", subscribe_uri));
 
-        debug!(method = "SUBSCRIBE", uri = %subscribe_uri, "SIP >>> sending");
-        let resp = self.tm.send(&mut req, self.cfg.server_addr, timeout)?;
+        let dest = self.outbound_dest();
+        debug!(method = "SUBSCRIBE", uri = %subscribe_uri, dest = %dest, "SIP >>> sending");
+        let resp = self.tm.send(&mut req, dest, timeout)?;
         debug!(method = "SUBSCRIBE", status = resp.status_code, reason = %resp.reason, "SIP <<< response");
         let branch = req.via_branch().to_string();
 
@@ -568,7 +576,7 @@ impl Client {
             let mut retry = self.build_request("SUBSCRIBE", subscribe_uri, Some(&extra));
             retry.set_header("To", &format!("<{}>", subscribe_uri));
             debug!(method = "SUBSCRIBE", "SIP >>> re-sending with auth");
-            let resp = self.tm.send(&mut retry, self.cfg.server_addr, timeout)?;
+            let resp = self.tm.send(&mut retry, dest, timeout)?;
             info!(method = "SUBSCRIBE", status = resp.status_code, reason = %resp.reason, "SIP <<< auth response");
             let retry_branch = retry.via_branch().to_string();
             self.tm.remove_tx(&retry_branch);
@@ -597,8 +605,9 @@ impl Client {
         req.set_header("To", &format!("<{}>", target_uri));
         req.body = body.to_vec();
 
-        debug!(method = "MESSAGE", uri = %target_uri, "SIP >>> sending");
-        let resp = self.tm.send(&mut req, self.cfg.server_addr, timeout)?;
+        let dest = self.outbound_dest();
+        debug!(method = "MESSAGE", uri = %target_uri, dest = %dest, "SIP >>> sending");
+        let resp = self.tm.send(&mut req, dest, timeout)?;
         debug!(method = "MESSAGE", status = resp.status_code, reason = %resp.reason, "SIP <<< response");
         let branch = req.via_branch().to_string();
 
@@ -627,7 +636,7 @@ impl Client {
             retry.set_header("To", &format!("<{}>", target_uri));
             retry.body = body.to_vec();
             debug!(method = "MESSAGE", "SIP >>> re-sending with auth");
-            let resp = self.tm.send(&mut retry, self.cfg.server_addr, timeout)?;
+            let resp = self.tm.send(&mut retry, dest, timeout)?;
             info!(method = "MESSAGE", status = resp.status_code, reason = %resp.reason, "SIP <<< auth response");
             let retry_branch = retry.via_branch().to_string();
             self.tm.remove_tx(&retry_branch);
@@ -644,7 +653,7 @@ impl Client {
             return Err(Error::Other("sip: client closed".into()));
         }
         debug!(method = %req.method, "SIP >>> in-dialog request");
-        let resp = self.tm.send(req, self.cfg.server_addr, timeout)?;
+        let resp = self.tm.send(req, self.outbound_dest(), timeout)?;
         debug!(method = %req.method, status = resp.status_code, reason = %resp.reason, "SIP <<< in-dialog response");
         let branch = req.via_branch().to_string();
         self.tm.remove_tx(&branch);
@@ -659,7 +668,8 @@ impl Client {
 
         debug!(method = "re-INVITE", "SIP >>> in-dialog re-INVITE");
         let invite_clone = req.clone();
-        let resp = self.tm.send(req, self.cfg.server_addr, timeout)?;
+        let dest = self.outbound_dest();
+        let resp = self.tm.send(req, dest, timeout)?;
         let branch = req.via_branch().to_string();
 
         // Consume provisional responses.
@@ -672,7 +682,7 @@ impl Client {
             // Send ACK for 2xx.
             let ack = self.build_ack(&invite_clone, &resp);
             self.tm.remove_tx(&branch);
-            self.tm.send_raw(&ack.to_bytes(), self.cfg.server_addr)?;
+            self.tm.send_raw(&ack.to_bytes(), dest)?;
         } else {
             self.tm.remove_tx(&branch);
         }
@@ -685,9 +695,10 @@ impl Client {
         self.tm.send_raw(data, dst)
     }
 
-    /// Sends a CRLF NAT keepalive packet to the server.
+    /// Sends a CRLF NAT keepalive packet to the SIP next-hop.
+    /// Targets the outbound proxy when configured, otherwise the registrar.
     pub fn send_keepalive(&self) -> Result<()> {
-        self.tm.send_raw(b"\r\n\r\n", self.cfg.server_addr)
+        self.tm.send_raw(b"\r\n\r\n", self.outbound_dest())
     }
 
     /// Builds an INVITE request with SDP body.
@@ -887,6 +898,91 @@ mod tests {
             via.contains(";branch="),
             "Via must retain branch parameter: {via}"
         );
+        client.close();
+    }
+
+    #[test]
+    fn register_routes_through_outbound_proxy_when_set() {
+        // When outbound_proxy is set, REGISTER goes to the proxy — not the
+        // registrar. Prior to v0.5.0 the proxy applied only to INVITE.
+        let proxy = UdpConn::bind("127.0.0.1:0").unwrap();
+        let proxy_addr = proxy.local_addr().unwrap();
+        let registrar = UdpConn::bind("127.0.0.1:0").unwrap();
+        let registrar_addr = registrar.local_addr().unwrap();
+
+        let cfg = ClientConfig {
+            local_addr: "127.0.0.1:0".into(),
+            server_addr: registrar_addr,
+            outbound_proxy: Some(proxy_addr),
+            username: "1001".into(),
+            password: "test".into(),
+            domain: "pbx.local".into(),
+            ..Default::default()
+        };
+        let client = Client::new(cfg).unwrap();
+
+        // Proxy accepts the REGISTER and replies 200 OK; the registrar must
+        // never see it.
+        let proxy_thread = std::thread::spawn(move || {
+            let (data, from) = proxy.receive(Duration::from_secs(2)).unwrap();
+            let req = super::super::message::parse(&data).unwrap();
+            assert_eq!(req.method, "REGISTER");
+            let mut resp = Message::new_response(200, "OK");
+            resp.set_header("Via", req.header("Via"));
+            resp.set_header("Call-ID", req.header("Call-ID"));
+            resp.set_header("CSeq", req.header("CSeq"));
+            resp.set_header("From", req.header("From"));
+            resp.set_header("To", &format!("{};tag=srv1", req.header("To")));
+            proxy.send(&resp.to_bytes(), from).unwrap();
+        });
+        let registrar_thread = std::thread::spawn(move || {
+            // Short timeout — we expect no traffic here.
+            registrar.receive(Duration::from_millis(500)).err()
+        });
+
+        let (code, _) = client.send_register(Duration::from_secs(5)).unwrap();
+        assert_eq!(code, 200);
+        proxy_thread.join().unwrap();
+        assert!(
+            registrar_thread.join().unwrap().is_some(),
+            "registrar must NOT receive REGISTER when outbound_proxy is set"
+        );
+        client.close();
+    }
+
+    #[test]
+    fn register_falls_back_to_server_addr_without_proxy() {
+        // Without outbound_proxy, REGISTER still goes to server_addr
+        // (the registrar). Sanity check that the new routing logic
+        // doesn't regress the default path.
+        let server = UdpConn::bind("127.0.0.1:0").unwrap();
+        let server_addr = server.local_addr().unwrap();
+        let cfg = ClientConfig {
+            local_addr: "127.0.0.1:0".into(),
+            server_addr,
+            username: "1001".into(),
+            password: "test".into(),
+            domain: "pbx.local".into(),
+            ..Default::default()
+        };
+        let client = Client::new(cfg).unwrap();
+
+        let handle = std::thread::spawn(move || {
+            let (data, from) = server.receive(Duration::from_secs(2)).unwrap();
+            let req = super::super::message::parse(&data).unwrap();
+            assert_eq!(req.method, "REGISTER");
+            let mut resp = Message::new_response(200, "OK");
+            resp.set_header("Via", req.header("Via"));
+            resp.set_header("Call-ID", req.header("Call-ID"));
+            resp.set_header("CSeq", req.header("CSeq"));
+            resp.set_header("From", req.header("From"));
+            resp.set_header("To", &format!("{};tag=srv1", req.header("To")));
+            server.send(&resp.to_bytes(), from).unwrap();
+        });
+
+        let (code, _) = client.send_register(Duration::from_secs(5)).unwrap();
+        assert_eq!(code, 200);
+        handle.join().unwrap();
         client.close();
     }
 

--- a/src/sip/client.rs
+++ b/src/sip/client.rs
@@ -58,6 +58,8 @@ pub struct ClientConfig {
     pub outbound_password: Option<String>,
     /// User-Agent header value (default: `"xphone"`).
     pub user_agent: String,
+    /// Append `;rport` (RFC 3581) to outgoing Via headers when `true`.
+    pub nat: bool,
 }
 
 impl Default for ClientConfig {
@@ -75,6 +77,7 @@ impl Default for ClientConfig {
             outbound_username: None,
             outbound_password: None,
             user_agent: "xphone".into(),
+            nat: false,
         }
     }
 }
@@ -111,6 +114,7 @@ impl Client {
             .map_err(|e| Error::Other(format!("sip: local addr: {}", e)))?;
         let via_transport = sip_conn.transport_name().to_string();
         let tm = TransactionManager::new(sip_conn);
+        tm.set_nat(cfg.nat);
         let call_id = transaction::generate_branch();
 
         // Compute a routable IP to advertise in Via/Contact headers.
@@ -311,6 +315,17 @@ impl Client {
     /// Returns the INVITE destination: outbound proxy if set, otherwise registrar.
     fn outbound_dest(&self) -> SocketAddr {
         self.cfg.outbound_proxy.unwrap_or(self.cfg.server_addr)
+    }
+
+    /// Builds a Via header value for outgoing requests. Appends `;rport`
+    /// (RFC 3581) when `cfg.nat` is enabled so responses return to the
+    /// source address the server actually observed.
+    pub(crate) fn build_via(&self, addr: SocketAddr, branch: &str) -> String {
+        let rport = if self.cfg.nat { ";rport" } else { "" };
+        format!(
+            "SIP/2.0/{} {};branch={}{}",
+            self.via_transport, addr, branch, rport
+        )
     }
 
     /// Returns the username for outbound INVITE auth (falls back to main credentials).
@@ -691,10 +706,7 @@ impl Client {
 
         // Pre-set Via so TransactionManager doesn't generate one with 0.0.0.0.
         let branch = transaction::generate_branch();
-        msg.set_header(
-            "Via",
-            &format!("SIP/2.0/{} {};branch={}", self.via_transport, local, branch),
-        );
+        msg.set_header("Via", &self.build_via(local, &branch));
 
         msg.set_header(
             "From",
@@ -749,11 +761,7 @@ impl Client {
         ack.set_header("CSeq", &format!("{} ACK", cseq_num));
         ack.set_header("Max-Forwards", "70");
         ack.set_header("User-Agent", &self.cfg.user_agent);
-        let via = format!(
-            "SIP/2.0/{} {};branch={}",
-            self.via_transport, self.advertised_addr, branch
-        );
-        ack.set_header("Via", &via);
+        ack.set_header("Via", &self.build_via(self.advertised_addr, branch));
         ack
     }
 
@@ -771,10 +779,7 @@ impl Client {
 
         // Pre-set Via so TransactionManager doesn't generate one with 0.0.0.0.
         let branch = transaction::generate_branch();
-        msg.set_header(
-            "Via",
-            &format!("SIP/2.0/{} {};branch={}", self.via_transport, local, branch),
-        );
+        msg.set_header("Via", &self.build_via(local, &branch));
 
         let from_tag = &transaction::generate_branch()[..15];
         msg.set_header(
@@ -843,6 +848,45 @@ mod tests {
         // Via should contain the correct transport.
         assert!(req.header("Via").contains("SIP/2.0/UDP"));
 
+        client.close();
+    }
+
+    #[test]
+    fn outgoing_via_has_no_rport_by_default() {
+        let client = Client::new(test_config(5060)).unwrap();
+        let req = client.build_request("REGISTER", "sip:pbx.local", None);
+        let via = req.header("Via");
+        assert!(
+            !via.contains(";rport"),
+            "default Via must not contain ;rport, got: {via}"
+        );
+        client.close();
+    }
+
+    #[test]
+    fn outgoing_via_contains_rport_when_nat_enabled() {
+        let cfg = ClientConfig {
+            local_addr: "127.0.0.1:0".into(),
+            server_addr: "127.0.0.1:5060".parse().unwrap(),
+            username: "1001".into(),
+            password: "test".into(),
+            domain: "pbx.local".into(),
+            nat: true,
+            ..Default::default()
+        };
+        let client = Client::new(cfg).unwrap();
+        let req = client.build_request("REGISTER", "sip:pbx.local", None);
+        let via = req.header("Via");
+        assert!(
+            via.contains(";rport"),
+            "nat=true Via must contain ;rport, got: {via}"
+        );
+        // The branch parameter must still come before rport so common parsers
+        // (which stop at the first `;` after branch) still see a rport marker.
+        assert!(
+            via.contains(";branch="),
+            "Via must retain branch parameter: {via}"
+        );
         client.close();
     }
 

--- a/src/sip/dialog.rs
+++ b/src/sip/dialog.rs
@@ -121,12 +121,7 @@ impl SipDialogUAC {
         let branch = generate_branch();
         req.set_header(
             "Via",
-            &format!(
-                "SIP/2.0/{} {};branch={}",
-                self.client.via_transport(),
-                self.client.local_addr(),
-                branch
-            ),
+            &self.client.build_via(self.client.local_addr(), &branch),
         );
 
         req.set_header("Call-ID", &self.call_id);
@@ -309,12 +304,7 @@ impl SipDialogUAS {
         let branch = generate_branch();
         req.set_header(
             "Via",
-            &format!(
-                "SIP/2.0/{} {};branch={}",
-                self.client.via_transport(),
-                self.client.local_addr(),
-                branch
-            ),
+            &self.client.build_via(self.client.local_addr(), &branch),
         );
 
         req.set_header("Call-ID", &self.call_id);

--- a/src/sip/transaction.rs
+++ b/src/sip/transaction.rs
@@ -35,6 +35,8 @@ pub struct TransactionManager {
     inner: Arc<Mutex<Inner>>,
     /// Transport name for Via headers (UDP, TCP, TLS).
     transport_name: String,
+    /// Append `;rport` (RFC 3581) to auto-generated Via headers when `true`.
+    nat: std::sync::atomic::AtomicBool,
     /// Dropping this sender closes the channel, signaling all receivers to stop.
     done_tx: Mutex<Option<Sender<()>>>,
     done_rx: Receiver<()>,
@@ -72,6 +74,7 @@ impl TransactionManager {
             local_addr,
             inner,
             transport_name,
+            nat: std::sync::atomic::AtomicBool::new(false),
             done_tx: Mutex::new(Some(done_tx)),
             done_rx,
             thread: Mutex::new(Some(thread)),
@@ -81,6 +84,12 @@ impl TransactionManager {
     /// Returns the transport name (UDP, TCP, TLS) for Via header construction.
     pub fn transport_name(&self) -> &str {
         &self.transport_name
+    }
+
+    /// Enables appending `;rport` (RFC 3581) to auto-generated Via headers.
+    pub fn set_nat(&self, enabled: bool) {
+        self.nat
+            .store(enabled, std::sync::atomic::Ordering::Relaxed);
     }
 
     /// Shuts down the read loop and cancels all pending transactions.
@@ -114,9 +123,14 @@ impl TransactionManager {
         let mut branch = req.via_branch().to_string();
         if branch.is_empty() {
             branch = generate_branch();
+            let rport = if self.nat.load(std::sync::atomic::Ordering::Relaxed) {
+                ";rport"
+            } else {
+                ""
+            };
             let via = format!(
-                "SIP/2.0/{} {};branch={}",
-                self.transport_name, self.local_addr, branch
+                "SIP/2.0/{} {};branch={}{}",
+                self.transport_name, self.local_addr, branch, rport
             );
             req.set_header("Via", &via);
         }

--- a/src/sip/ua.rs
+++ b/src/sip/ua.rs
@@ -92,6 +92,7 @@ impl SipUA {
             outbound_username: cfg.outbound_username.clone(),
             outbound_password: cfg.outbound_password.clone(),
             user_agent: cfg.user_agent.clone(),
+            nat: cfg.nat,
         };
 
         let client = Arc::new(Client::new(client_cfg)?);

--- a/src/turn.rs
+++ b/src/turn.rs
@@ -155,12 +155,10 @@ impl TurnClient {
                 stun::ATTR_XOR_RELAYED_ADDRESS => {
                     relay = Some(stun::parse_xor_address(v)?);
                 }
-                stun::ATTR_LIFETIME => {
-                    if v.len() >= 4 {
-                        let lt = u32::from_be_bytes([v[0], v[1], v[2], v[3]]);
-                        *self.lifetime.lock() = lt;
-                        debug!(lifetime = lt, "TURN: server lifetime");
-                    }
+                stun::ATTR_LIFETIME if v.len() >= 4 => {
+                    let lt = u32::from_be_bytes([v[0], v[1], v[2], v[3]]);
+                    *self.lifetime.lock() = lt;
+                    debug!(lifetime = lt, "TURN: server lifetime");
                 }
                 _ => {}
             }


### PR DESCRIPTION
Three xphone-go ports bundled for the v0.5.0 release.

## Summary

### Issue A — NAT-friendly Via (`;rport`, RFC 3581)
`Config::nat` (opt-in, default `false`) / `PhoneBuilder::with_nat(true)` appends `;rport` to outgoing `Via` headers so the server sends responses back to the source IP/port it actually observed. Harmless on servers that don't understand it.

Covers every outbound request path:
- `Client` — REGISTER, INVITE, ACK, build_request (BYE out-of-dialog, SUBSCRIBE, MESSAGE)
- `SipDialogUAC` / `SipDialogUAS` — in-dialog BYE / re-INVITE / REFER / INFO (via `Client::build_via`)
- `TransactionManager` — fallback Via for callers that don't pre-set one

### Issue #96 — surface REGISTER failure details (BREAKING)
`Error::RegistrationFailed` is now a struct variant `{ code: u16, reason: String }` carrying the last SIP status and reason-phrase observed across retry attempts.
- `code == 0` + transport-error reason when no SIP response was ever received.
- Surfaced through `Registry::start()` return, `on_error` callback, `Phone::connect()` return, and the final `warn!` on retry exhaustion.
- `Display` suppresses `0` code and empty reason.

**Breaking change:** callers pattern-matching `Error::RegistrationFailed` must update to the struct form.

### Outbound-proxy issue — route all methods through proxy
`Config::outbound_proxy` now routes **all** outbound SIP requests (REGISTER, INVITE, SUBSCRIBE, MESSAGE, in-dialog BYE/re-INVITE/REFER/INFO, ACK, NAT keep-alives), not just INVITE. For TCP/TLS the transport connection also targets the proxy. Matches how outbound-proxy deployments (Kamailio, OpenSIPS, Asterisk) actually behave.

**Behavior change** for anyone who was setting `outbound_proxy` and relying on REGISTER bypassing it. No change when `outbound_proxy` is unset.

## Also included
Rust 1.95 `collapsible_match` clippy fixes in `turn.rs`, `call.rs`, `dialog_info.rs` — required to keep CI green after the stable toolchain bump.

## Tests (833 passing on Rust 1.95)
- rport: `outgoing_via_has_no_rport_by_default`, `outgoing_via_contains_rport_when_nat_enabled`, `nat_default_is_off`, `phone_builder_with_nat_enables_rport`
- REGISTER failure detail: `start_surfaces_403_code_and_reason`, `start_transport_failure_surfaces_code_zero`, `start_error_callback_receives_detailed_error`, `registration_failed_display_skips_zero_and_empty`
- outbound_proxy scope: `register_routes_through_outbound_proxy_when_set`, `register_falls_back_to_server_addr_without_proxy`

## Notes
- `TransactionManager::set_nat` uses an `AtomicBool` (single-writer at construction, `Relaxed` ordering).
- `Phone::Inner::last_reg_error` stashes the Registry error so `Phone::connect()` can propagate the typed error without changing the `connect_with_transport` signature (which has 40+ call sites in tests).
- Trunk mode (`src/trunk/dialog.rs`) intentionally untouched — trunk servers don't traverse NAT.
- No version bump in this PR; 0.5.0 bump will happen on a separate `release/v0.5.0` branch per the project's release workflow.