### PR TITLE
Align rport scope with xphone-go PR #97

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
-- **NAT-friendly Via (`;rport`, RFC 3581)** — `Config.nat` / `PhoneBuilder::with_nat(true)` appends `;rport` to outgoing SIP `Via` headers so the server sends responses back to the source IP/port it actually observed. Opt-in (default `false`); harmless on servers that don't understand the parameter. Covers every outbound request path (REGISTER, INVITE, ACK, BYE, SUBSCRIBE, MESSAGE, etc.) and the `TransactionManager` fallback. (xphone-go issue A)
+- **NAT-friendly Via (`;rport`, RFC 3581)** — `Config.nat` / `PhoneBuilder::with_nat(true)` appends `;rport` to outgoing SIP `Via` headers so the server sends responses back to the source IP/port it actually observed. Opt-in (default `false`); harmless on servers that don't understand the parameter. Covers every outbound request path (REGISTER, INVITE, ACK, BYE, SUBSCRIBE, MESSAGE, etc.) and the `TransactionManager` fallback. **Gated on UDP transport** per RFC 3581 — TCP/TLS already do symmetric response routing over the existing connection, so the parameter is ignored there. (xphone-go issue A / xphone-go PR #97 parity)
+- **`ServerConfig.nat` for trunk mode** — opt-in flag that appends `;rport` to trunk outbound Via headers (INVITE, in-dialog BYE/re-INVITE/REFER/INFO, 2xx ACK). Trunk servers are UDP-only by construction, so no transport gating. Default `false`.
 - **Separate digest auth username for REGISTER** — `Config.auth_username` / `PhoneBuilder::auth_username()` decouples the SIP AOR from the digest `username` parameter. The REGISTER Request-URI, From, To, and Contact still use `Config.username`; only the digest credentials switch to `auth_username`. Enables registering `sip:<aor>@host` while authenticating as a shared trunk auth-user. Falls back to `username` when unset (no behavior change for existing callers).
 
 ### Changed

--- a/src/config.rs
+++ b/src/config.rs
@@ -49,11 +49,12 @@ pub struct Config {
     /// Interval for NAT keep-alive packets. `None` disables keep-alive.
     pub nat_keepalive_interval: Option<Duration>,
 
-    /// Enable NAT-friendly SIP transport behaviour. When `true`, outgoing
-    /// Via headers include the `;rport` parameter (RFC 3581) so the server
-    /// sends responses to the source IP/port the request actually arrived
-    /// from. Harmless on servers that don't understand it. Opt-in so
-    /// existing deployments see no change.
+    /// Enable NAT-friendly SIP transport behaviour. When `true` **and** the
+    /// transport is UDP, outgoing Via headers include the `;rport` parameter
+    /// (RFC 3581) so the server sends responses to the source IP/port the
+    /// request actually arrived from. Ignored on TCP/TLS where symmetric
+    /// response routing happens implicitly over the existing connection.
+    /// Opt-in so existing deployments see no change.
     pub nat: bool,
 
     /// Override the local IP advertised in SDP/Via/Contact.

--- a/src/sip/client.rs
+++ b/src/sip/client.rs
@@ -328,10 +328,16 @@ impl Client {
     }
 
     /// Builds a Via header value for outgoing requests. Appends `;rport`
-    /// (RFC 3581) when `cfg.nat` is enabled so responses return to the
-    /// source address the server actually observed.
+    /// (RFC 3581) when `cfg.nat` is enabled **and** the transport is UDP.
+    /// Per RFC 3581, `rport` is only meaningful for unreliable transports —
+    /// TCP and TLS do symmetric response routing implicitly via the existing
+    /// connection, so appending the parameter there is noise at best.
     pub(crate) fn build_via(&self, addr: SocketAddr, branch: &str) -> String {
-        let rport = if self.cfg.nat { ";rport" } else { "" };
+        let rport = if self.cfg.nat && self.via_transport == "UDP" {
+            ";rport"
+        } else {
+            ""
+        };
         format!(
             "SIP/2.0/{} {};branch={}{}",
             self.via_transport, addr, branch, rport
@@ -910,6 +916,46 @@ mod tests {
         assert!(
             via.contains(";branch="),
             "Via must retain branch parameter: {via}"
+        );
+        client.close();
+    }
+
+    #[test]
+    fn outgoing_via_omits_rport_on_tcp_even_when_nat_enabled() {
+        // Per RFC 3581, ;rport is only meaningful on unreliable transports.
+        // TCP/TLS do symmetric response routing over the existing connection,
+        // so we must not advertise ;rport even when Config.nat is true.
+        use std::net::TcpListener;
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let server_addr = listener.local_addr().unwrap();
+        // Spawn an accept loop so Client::new's TCP connect completes.
+        std::thread::spawn(move || {
+            let _ = listener.accept();
+            std::thread::sleep(Duration::from_secs(2));
+        });
+
+        let cfg = ClientConfig {
+            local_addr: "127.0.0.1:0".into(),
+            server_addr,
+            username: "1001".into(),
+            password: "test".into(),
+            domain: "pbx.local".into(),
+            transport: "tcp".into(),
+            nat: true, // opt-in, but must be ignored on TCP
+            ..Default::default()
+        };
+        let client = Client::new(cfg).unwrap();
+        assert_eq!(client.via_transport(), "TCP");
+
+        let req = client.build_request("REGISTER", "sip:pbx.local", None);
+        let via = req.header("Via");
+        assert!(
+            !via.contains(";rport"),
+            "TCP Via must never contain ;rport even with nat=true, got: {via}"
+        );
+        assert!(
+            via.contains("SIP/2.0/TCP"),
+            "Via transport must be TCP, got: {via}"
         );
         client.close();
     }

--- a/src/sip/transaction.rs
+++ b/src/sip/transaction.rs
@@ -123,7 +123,10 @@ impl TransactionManager {
         let mut branch = req.via_branch().to_string();
         if branch.is_empty() {
             branch = generate_branch();
-            let rport = if self.nat.load(std::sync::atomic::Ordering::Relaxed) {
+            // Per RFC 3581, ;rport is only meaningful on unreliable transports.
+            let rport = if self.nat.load(std::sync::atomic::Ordering::Relaxed)
+                && self.transport_name == "UDP"
+            {
                 ";rport"
             } else {
                 ""

--- a/src/trunk/config.rs
+++ b/src/trunk/config.rs
@@ -14,6 +14,10 @@ pub struct ServerConfig {
     /// IP address advertised in SDP for RTP media. When the server listens on
     /// `0.0.0.0`, this must be set to the reachable IP (e.g. a container IP).
     pub rtp_address: Option<IpAddr>,
+    /// Append `;rport` (RFC 3581) to outgoing Via headers. Trunk servers are
+    /// UDP-only by construction, so unlike [`Config::nat`](crate::Config::nat)
+    /// this flag is not gated on transport. Opt-in; default `false`.
+    pub nat: bool,
 }
 
 impl Default for ServerConfig {
@@ -24,6 +28,7 @@ impl Default for ServerConfig {
             rtp_port_min: 0,
             rtp_port_max: 0,
             rtp_address: None,
+            nat: false,
         }
     }
 }

--- a/src/trunk/dialog.rs
+++ b/src/trunk/dialog.rs
@@ -40,6 +40,8 @@ pub struct TrunkDialog {
     tx: mpsc::Sender<SipOutgoing>,
     remote_addr: SocketAddr,
     local_addr: SocketAddr,
+    /// Append `;rport` (RFC 3581) to outgoing Via headers (trunk is UDP-only).
+    nat: bool,
     sip_call_id: String,
     remote_tag: Mutex<String>,
     /// Pre-computed From header with local tag appended.
@@ -66,6 +68,7 @@ impl TrunkDialog {
         remote_addr: SocketAddr,
         invite: &Message,
         local_tag: String,
+        nat: bool,
     ) -> Self {
         // Build headers map (lowercase keys for case-insensitive lookup).
         let mut headers = HashMap::with_capacity(6);
@@ -103,6 +106,7 @@ impl TrunkDialog {
             tx,
             remote_addr,
             local_addr,
+            nat,
             sip_call_id: invite.header("Call-ID").to_string(),
             remote_tag: Mutex::new(String::new()),
             local_from_tagged,
@@ -121,6 +125,7 @@ impl TrunkDialog {
     }
 
     /// Create a UAC dialog for an outbound call to a peer.
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn new_outbound(
         tx: mpsc::Sender<SipOutgoing>,
         local_addr: SocketAddr,
@@ -129,6 +134,7 @@ impl TrunkDialog {
         local_tag: String,
         from_header: String,
         to_header: String,
+        nat: bool,
     ) -> Self {
         let contact_uri = format!("sip:{}@{}", extract_uri(&to_header), remote_addr);
 
@@ -149,6 +155,7 @@ impl TrunkDialog {
             tx,
             remote_addr,
             local_addr,
+            nat,
             sip_call_id,
             remote_tag: Mutex::new(String::new()),
             local_from_tagged,
@@ -221,9 +228,10 @@ impl TrunkDialog {
             contact_uri
         };
         let mut req = Message::new_request(method, &request_uri);
+        let rport = if self.nat { ";rport" } else { "" };
         req.set_header(
             "Via",
-            &format!("SIP/2.0/UDP {};branch={}", self.local_addr, branch),
+            &format!("SIP/2.0/UDP {};branch={}{}", self.local_addr, branch, rport),
         );
 
         let remote_tag = self.remote_tag.lock().clone();
@@ -362,6 +370,7 @@ mod tests {
             "10.0.0.1:5060".parse().unwrap(),
             &invite,
             "localtag123".into(),
+            false,
         );
         (dialog, rx)
     }
@@ -376,6 +385,7 @@ mod tests {
             "uactag456".into(),
             "<sip:1001@127.0.0.1:5080>".into(),
             "<sip:1002@10.0.0.1:5060>".into(),
+            false,
         );
         (dialog, rx)
     }
@@ -421,6 +431,7 @@ mod tests {
             "10.0.0.1:5060".parse().unwrap(),
             &invite,
             "localtag123".into(),
+            false,
         );
         dialog.respond(200, "OK", b"v=0\r\n").unwrap();
 

--- a/src/trunk/server.rs
+++ b/src/trunk/server.rs
@@ -252,6 +252,7 @@ impl Server {
             local_tag.clone(),
             from_header,
             to_header,
+            self.config.nat,
         ));
 
         let call = Call::new_outbound(dialog.clone(), DialOptions::default());
@@ -296,6 +297,7 @@ impl Server {
             from,
             to,
             sdp: &sdp,
+            nat: self.config.nat,
         });
 
         Ok(call)
@@ -607,6 +609,7 @@ impl Server {
             remote_addr,
             invite,
             local_tag,
+            self.config.nat,
         ));
 
         let call = Call::new_inbound(dialog.clone());
@@ -744,7 +747,7 @@ impl Server {
                     }
                 }
                 call.simulate_response(200, "OK");
-                send_ack(sip_tx, msg, &sip_call_id, local_addr);
+                send_ack(sip_tx, msg, &sip_call_id, local_addr, self.config.nat);
             }
             _ => {
                 warn!("outbound call {sip_call_id} rejected with {code}");
@@ -894,6 +897,7 @@ fn send_ack(
     ok_response: &Message,
     sip_call_id: &str,
     local_addr: SocketAddr,
+    nat: bool,
 ) {
     let contact = ok_response.header("Contact");
     let request_uri = if !contact.is_empty() {
@@ -908,7 +912,11 @@ fn send_ack(
 
     let branch = generate_branch();
     let mut ack = Message::new_request("ACK", &request_uri);
-    ack.set_header("Via", &format!("SIP/2.0/UDP {local_addr};branch={branch}"));
+    let rport = if nat { ";rport" } else { "" };
+    ack.set_header(
+        "Via",
+        &format!("SIP/2.0/UDP {local_addr};branch={branch}{rport}"),
+    );
     ack.set_header("From", ok_response.header("From"));
     ack.set_header("To", ok_response.header("To"));
     ack.set_header("Call-ID", sip_call_id);
@@ -939,6 +947,7 @@ struct BuildInviteParams<'a> {
     from: &'a str,
     to: &'a str,
     sdp: &'a str,
+    nat: bool,
 }
 
 fn build_and_send_invite(params: &BuildInviteParams<'_>) {
@@ -946,9 +955,10 @@ fn build_and_send_invite(params: &BuildInviteParams<'_>) {
     let request_uri = format!("sip:{}@{}", params.to, params.remote_addr);
 
     let mut invite = Message::new_request("INVITE", &request_uri);
+    let rport = if params.nat { ";rport" } else { "" };
     invite.set_header(
         "Via",
-        &format!("SIP/2.0/UDP {};branch={branch}", params.local_addr),
+        &format!("SIP/2.0/UDP {};branch={branch}{rport}", params.local_addr),
     );
     invite.set_header(
         "From",
@@ -1137,6 +1147,7 @@ mod tests {
             &ok_resp,
             "ack-test@xphone",
             "127.0.0.1:5080".parse().unwrap(),
+            false,
         );
 
         let outgoing = rx.try_recv().unwrap();
@@ -1167,6 +1178,7 @@ mod tests {
             &ok_resp,
             "ack-test@xphone",
             "127.0.0.1:5080".parse().unwrap(),
+            false,
         );
 
         let outgoing = rx.try_recv().unwrap();
@@ -1208,6 +1220,7 @@ mod tests {
             from: "1001",
             to: "1002",
             sdp: "v=0\r\n",
+            nat: false,
         });
 
         let outgoing = rx.try_recv().unwrap();
@@ -1226,6 +1239,45 @@ mod tests {
             outgoing.addr,
             "10.0.0.1:5060".parse::<SocketAddr>().unwrap()
         );
+        // Default nat=false must not advertise ;rport.
+        assert!(
+            !msg.header("Via").contains(";rport"),
+            "default Via must not contain ;rport, got: {}",
+            msg.header("Via")
+        );
+    }
+
+    #[test]
+    fn outbound_invite_advertises_rport_when_nat_enabled() {
+        let (tx, mut rx) = mpsc::channel(64);
+        build_and_send_invite(&BuildInviteParams {
+            sip_tx: &tx,
+            local_addr: "127.0.0.1:5080".parse().unwrap(),
+            remote_addr: "10.0.0.1:5060".parse().unwrap(),
+            sip_call_id: "nat-test@xphone",
+            local_tag: "localtag1",
+            from: "1001",
+            to: "1002",
+            sdp: "v=0\r\n",
+            nat: true,
+        });
+
+        let outgoing = rx.try_recv().unwrap();
+        let msg = message::parse(&outgoing.data).unwrap();
+        let via = msg.header("Via");
+        assert!(
+            via.contains(";rport"),
+            "nat=true trunk Via must contain ;rport, got: {via}"
+        );
+        assert!(
+            via.contains(";branch="),
+            "Via must retain branch parameter: {via}"
+        );
+    }
+
+    #[test]
+    fn server_config_nat_defaults_to_false() {
+        assert!(!ServerConfig::default().nat);
     }
 
     #[test]


### PR DESCRIPTION
Tightens and extends the `Config.nat` (rport) support added in PR #58 to match xphone-go's WithNAT implementation landed in xphone-go PR #97.

## Changes

### 1. Gate `;rport` on UDP transport
Per RFC 3581, `;rport` is only meaningful on unreliable transports. TCP/TLS do symmetric response routing over the existing connection, so advertising the parameter there is noise. Previously Rust appended `;rport` regardless of transport.

- `Client::build_via` now gates on `self.via_transport == "UDP"` in addition to `cfg.nat`.
- `TransactionManager` fallback Via gates identically via its own `transport_name` field.
- `Config::nat` docstring updated to reflect the UDP-only semantics.

### 2. Add `ServerConfig::nat` for trunk mode
Trunk servers previously had no way to opt into `;rport`. Matches xphone-go's `ServerConfig.NAT`.

- New `nat: bool` on `ServerConfig` (default `false`).
- Plumbed through `TrunkDialog::new` and `TrunkDialog::new_outbound` (new `nat` parameter).
- `BuildInviteParams` gains a `nat` field.
- `send_ack` takes `nat` as a new parameter.
- Trunk is UDP-only by construction so no transport gate.

## Tests (842 passing on Rust 1.95)
- `outgoing_via_omits_rport_on_tcp_even_when_nat_enabled` — spins up a real TCP listener, connects a Client with `nat=true, transport=tcp`, asserts the outgoing Via has `SIP/2.0/TCP` and no `;rport`.
- `outbound_invite_advertises_rport_when_nat_enabled` — verifies trunk outbound INVITE carries `;rport` when `ServerConfig.nat=true`.
- Updated `build_outbound_invite_message` to also assert default `nat=false` produces no `;rport`.
- `server_config_nat_defaults_to_false` — defaults check.

## Notes
- `#[allow(clippy::too_many_arguments)]` on `TrunkDialog::new_outbound` (now 8 args). Could be collapsed into a params struct later if it grows.
- No changes to the existing `Config::nat` tests — they already covered the UDP-enabled case correctly.