### PR TITLE
Bump version to 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-04-22
+
 ### Added
 
 - **NAT-friendly Via (`;rport`, RFC 3581)** — `Config.nat` / `PhoneBuilder::with_nat(true)` appends `;rport` to outgoing SIP `Via` headers so the server sends responses back to the source IP/port it actually observed. Opt-in (default `false`); harmless on servers that don't understand the parameter. Covers every outbound request path (REGISTER, INVITE, ACK, BYE, SUBSCRIBE, MESSAGE, etc.) and the `TransactionManager` fallback. **Gated on UDP transport** per RFC 3581 — TCP/TLS already do symmetric response routing over the existing connection, so the parameter is ignored there. (xphone-go issue A / xphone-go PR #97 parity)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2669,7 +2669,7 @@ checksum = "3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f"
 
 [[package]]
 name = "xphone"
-version = "0.4.8"
+version = "0.5.0"
 dependencies = [
  "aes",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xphone"
-version = "0.4.8"
+version = "0.5.0"
 edition = "2021"
 rust-version = "1.87"
 description = "SIP telephony library with event-driven API — handles SIP signaling, RTP media, codecs, and call state"


### PR DESCRIPTION
## Summary

Release v0.5.0. Minor bump (pre-1.0 semver) for the breaking change to `Error::RegistrationFailed`.

### Included since v0.4.8

- NAT-friendly Via (`;rport`, RFC 3581) for Phone + Server (PR #58, #59)
- Separate digest auth username for REGISTER (PR #57)
- `Config.outbound_proxy` now routes all outbound SIP requests, not just INVITE (PR #58)
- **BREAKING**: `Error::RegistrationFailed` now carries `{ code: u16, reason: String }` (PR #58)

Full details in CHANGELOG.md.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` (867 tests passing: 842 unit + 12 fakepbx + 11 server + 2 doctest)
- [ ] After merge: tag `v0.5.0` and push to trigger `publish.yml`