### PR TITLE
DTMF reliability: honour codec_override, auto-inject PT 101, verify negotiation, fix Both mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - **`Codec::TelephoneEvent`** (PT 101) exported from `crate::types`. Previously PT 101 was hardcoded in SDP offers but not representable through the public `Codec` enum — callers could not include it via `DialOptions::codec_override`. (xphone-rust#63)
-- **`DialOptions::rtp_address`** / **`DialOptionsBuilder::rtp_address()`** — per-call override of the local IP advertised in the SDP `c=` line. Takes precedence over `Config::local_ip`. Useful on multi-homed hosts when individual calls need different source-routable media addresses. Resolution order: `DialOptions::rtp_address` → `Config::local_ip` → STUN-mapped address → route-lookup heuristic. **Scope is intentionally SDP-only** — does not modify `Contact`/`Via`, which stay anchored to the bound SIP socket so REGISTER-behind-NAT keeps working (xphone-go's `WithRTPAddress` conflated these scopes and broke Docker-bridge deployments). (xphone-rust#65)
+- **`DialOptions::rtp_address`** / **`DialOptionsBuilder::rtp_address()`** — per-call override of the local IP advertised in the SDP `c=` line. Takes precedence over `Config::local_ip`. Useful on multi-homed hosts when individual calls need different source-routable media addresses. Resolution order: `DialOptions::rtp_address` → `Config::local_ip` → STUN-mapped address → route-lookup heuristic. **Scope is intentionally SDP-only** — does not modify `Contact`/`Via`, so registrar NAT learning (rport / `received` on REGISTER, keepalives) continues to route inbound signaling correctly in Docker-bridge and other asymmetric-port setups. (xphone-rust#65)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- **`Codec::TelephoneEvent`** (PT 101) exported from `crate::types`. Previously PT 101 was hardcoded in SDP offers but not representable through the public `Codec` enum — callers could not include it via `DialOptions::codec_override`. (xphone-rust#63)
+- **`DialOptions::rtp_address`** / **`DialOptionsBuilder::rtp_address()`** — per-call override of the local IP advertised in SDP. Takes precedence over `Config::local_ip`. Useful on multi-homed hosts when individual calls need different source-routable addresses. Resolution order: `DialOptions::rtp_address` → `Config::local_ip` → STUN-mapped address → route-lookup heuristic. (xphone-rust#65)
+
+### Changed
+
+- **`DialOptions::codec_override` is now actually honoured.** Previously the field existed and the builder accepted it, but `Phone::dial()` ignored it and built the SDP offer from a hardcoded `[8, 0, 9, 101]` list. Now the offer is resolved in order: `DialOptions::codec_override` → `Config::codec_prefs` → `[8, 0, 9, 101]`. (xphone-rust#63)
+- **DTMF PT 101 is auto-injected into outbound SDP** when `DtmfMode` is `Rfc4733` or `Both` and the resolved codec list doesn't already include it. Skipped for `SipInfo` (telephone-event isn't used there). Removes the common \"I set my own codecs and now DTMF doesn't work\" foot-gun. (xphone-rust#63)
+- **BREAKING: `Call::send_dtmf` now returns `Err(Error::DtmfNotNegotiated)`** in `DtmfMode::Rfc4733` when PT 101 was not negotiated with the remote, instead of silently writing RTP packets into the void. Add a match arm to catch this error, or switch to `DtmfMode::Both` for automatic SIP INFO fallback. (xphone-rust#63)
+- **BREAKING: `DtmfMode::Both` now actually sends both transports** — RFC 4733 RTP (when negotiated) **and** SIP INFO on every digit. Previously `Both` was a misnomer: it sent RTP only and merely *accepted* SIP INFO on inbound. Matches pjsua / FreeSWITCH / Asterisk convention and makes middlebox-stripped DTMF self-healing. Well-behaved remotes may now double-report digits in `Both` mode — switch to `Rfc4733` or `SipInfo` if single-transport is required. (xphone-rust#64)
+
 ## [0.5.0] - 2026-04-22
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - **`Codec::TelephoneEvent`** (PT 101) exported from `crate::types`. Previously PT 101 was hardcoded in SDP offers but not representable through the public `Codec` enum — callers could not include it via `DialOptions::codec_override`. (xphone-rust#63)
-- **`DialOptions::rtp_address`** / **`DialOptionsBuilder::rtp_address()`** — per-call override of the local IP advertised in SDP. Takes precedence over `Config::local_ip`. Useful on multi-homed hosts when individual calls need different source-routable addresses. Resolution order: `DialOptions::rtp_address` → `Config::local_ip` → STUN-mapped address → route-lookup heuristic. (xphone-rust#65)
+- **`DialOptions::rtp_address`** / **`DialOptionsBuilder::rtp_address()`** — per-call override of the local IP advertised in the SDP `c=` line. Takes precedence over `Config::local_ip`. Useful on multi-homed hosts when individual calls need different source-routable media addresses. Resolution order: `DialOptions::rtp_address` → `Config::local_ip` → STUN-mapped address → route-lookup heuristic. **Scope is intentionally SDP-only** — does not modify `Contact`/`Via`, which stay anchored to the bound SIP socket so REGISTER-behind-NAT keeps working (xphone-go's `WithRTPAddress` conflated these scopes and broke Docker-bridge deployments). (xphone-rust#65)
 
 ### Changed
 

--- a/src/call.rs
+++ b/src/call.rs
@@ -73,8 +73,12 @@ impl Drop for VideoUpgradeRequest {
     }
 }
 
-/// Default codec preference order (payload types).
-const DEFAULT_CODEC_PREFS: &[i32] = &[8, 0, 9, 101, 111];
+/// RFC 4733 telephone-event payload type used for out-of-band DTMF.
+pub(crate) const PT_TELEPHONE_EVENT: i32 = 101;
+
+/// Default audio codec preference order (payload types): PCMA, PCMU, G.722,
+/// telephone-event (DTMF), Opus.
+pub(crate) const DEFAULT_CODEC_PREFS: &[i32] = &[8, 0, 9, PT_TELEPHONE_EVENT, 111];
 
 fn new_call_id() -> String {
     let mut buf = [0u8; 16];
@@ -214,6 +218,9 @@ struct CallInner {
     media_active: bool,
     /// DTMF transport mode for this call.
     dtmf_mode: crate::config::DtmfMode,
+    /// True when RFC 4733 telephone-event (PT 101) appears in both our codec
+    /// preferences and the remote's SDP. Set during codec negotiation.
+    telephone_event_negotiated: bool,
     /// Whether SRTP is enabled for this call.
     srtp_enabled: bool,
     /// Local SRTP keying material (base64 inline key).
@@ -281,6 +288,7 @@ impl Call {
                 codec: Codec::PCMU,
                 media_active: false,
                 dtmf_mode: crate::config::DtmfMode::Rfc4733,
+                telephone_event_negotiated: false,
                 srtp_enabled: false,
                 srtp_local_key: String::new(),
                 srtp_remote_key: String::new(),
@@ -334,6 +342,7 @@ impl Call {
                 codec: Codec::PCMU,
                 media_active: false,
                 dtmf_mode: crate::config::DtmfMode::Rfc4733,
+                telephone_event_negotiated: false,
                 srtp_enabled: false,
                 srtp_local_key: String::new(),
                 srtp_remote_key: String::new(),
@@ -607,18 +616,38 @@ impl Call {
     }
 
     fn negotiate_codec(inner: &mut CallInner, sess: &sdp::Session) {
-        // Audio codec negotiation.
-        let remote_codecs: &[i32] = sess
+        // Audio codec negotiation: exclude PT 101 (telephone-event) — it's not
+        // an audio codec, it's negotiated separately below for DTMF.
+        let remote_audio: Vec<i32> = sess
             .audio_media()
-            .map(|m| m.codecs.as_slice())
-            .unwrap_or(&[]);
-        let prefs = Self::resolve_codec_prefs(inner);
-        let pt = sdp::negotiate_codec(prefs, remote_codecs);
+            .map(|m| {
+                m.codecs
+                    .iter()
+                    .copied()
+                    .filter(|&p| p != PT_TELEPHONE_EVENT)
+                    .collect()
+            })
+            .unwrap_or_default();
+        let audio_prefs: Vec<i32> = Self::resolve_codec_prefs(inner)
+            .iter()
+            .copied()
+            .filter(|&p| p != PT_TELEPHONE_EVENT)
+            .collect();
+        let pt = sdp::negotiate_codec(&audio_prefs, &remote_audio);
         if pt >= 0 {
             if let Some(c) = Codec::from_payload_type(pt) {
                 inner.codec = c;
             }
         }
+
+        // Telephone-event (PT 101) negotiation — tracked separately for DTMF.
+        let remote_has_te = sess
+            .audio_media()
+            .map(|m| m.codecs.contains(&PT_TELEPHONE_EVENT))
+            .unwrap_or(false);
+        let local_has_te = Self::resolve_codec_prefs(inner).contains(&PT_TELEPHONE_EVENT);
+        inner.telephone_event_negotiated = remote_has_te && local_has_te;
+
         // Video codec negotiation (skip if remote rejected video with port 0).
         if let Some(vm) = sess.video_media() {
             if vm.port > 0 {
@@ -1113,11 +1142,15 @@ impl Call {
     /// Sends a DTMF digit (e.g., `"1"`, `"#"`, `"*"`).
     ///
     /// The transport method depends on the configured [`DtmfMode`](crate::config::DtmfMode):
-    /// - `Rfc4733` — RTP telephone-event packets (default)
-    /// - `SipInfo` — SIP INFO with `application/dtmf-relay` body
-    /// - `Both` — sends via RFC 4733
+    /// - `Rfc4733` — RFC 4733 RTP telephone-event packets (default). Returns
+    ///   [`Error::DtmfNotNegotiated`] if PT 101 was not negotiated with the
+    ///   remote.
+    /// - `SipInfo` — SIP INFO with `application/dtmf-relay` body (RFC 2976).
+    /// - `Both` — sends via RFC 4733 (when PT 101 was negotiated) **and** SIP
+    ///   INFO, in that order. Maximally compatible: if a middlebox strips one
+    ///   transport the other usually survives.
     pub fn send_dtmf(&self, digit: &str) -> Result<()> {
-        let (rtp_socket, remote_ip, remote_port, dtmf_mode) = {
+        let (rtp_socket, remote_ip, remote_port, dtmf_mode, te_negotiated) = {
             let inner = self.inner.lock();
             if inner.state != CallState::Active {
                 return Err(Error::InvalidState);
@@ -1127,6 +1160,7 @@ impl Call {
                 inner.remote_ip.clone(),
                 inner.remote_port,
                 inner.dtmf_mode,
+                inner.telephone_event_negotiated,
             )
         };
         if dtmf::digit_to_code(digit).is_none() {
@@ -1136,17 +1170,46 @@ impl Call {
             crate::config::DtmfMode::SipInfo => {
                 self.dlg.send_info_dtmf(digit, 160)?;
             }
-            crate::config::DtmfMode::Rfc4733 | crate::config::DtmfMode::Both => {
-                let pkts = dtmf::encode_dtmf(digit, 0, 0, 0)?;
-                if let Some(sock) = rtp_socket {
-                    if !remote_ip.is_empty() && remote_port > 0 {
-                        if let Ok(addr) =
-                            format!("{}:{}", remote_ip, remote_port).parse::<std::net::SocketAddr>()
-                        {
-                            for pkt in &pkts {
-                                let _ = sock.send_to(&pkt.to_bytes(), addr);
-                            }
-                        }
+            crate::config::DtmfMode::Rfc4733 => {
+                if !te_negotiated {
+                    return Err(Error::DtmfNotNegotiated);
+                }
+                Self::send_rfc4733_dtmf(digit, &rtp_socket, &remote_ip, remote_port)?;
+            }
+            crate::config::DtmfMode::Both => {
+                if te_negotiated {
+                    // Swallow RTP send errors so SIP INFO still fires — the
+                    // whole point of `Both` is that one transport surviving
+                    // masks the other failing.
+                    if let Err(e) =
+                        Self::send_rfc4733_dtmf(digit, &rtp_socket, &remote_ip, remote_port)
+                    {
+                        tracing::warn!(
+                            "RFC 4733 DTMF failed in Both mode: {}; SIP INFO will still fire",
+                            e
+                        );
+                    }
+                }
+                self.dlg.send_info_dtmf(digit, 160)?;
+            }
+        }
+        Ok(())
+    }
+
+    fn send_rfc4733_dtmf(
+        digit: &str,
+        rtp_socket: &Option<Arc<UdpSocket>>,
+        remote_ip: &str,
+        remote_port: i32,
+    ) -> Result<()> {
+        let pkts = dtmf::encode_dtmf(digit, 0, 0, 0)?;
+        if let Some(sock) = rtp_socket {
+            if !remote_ip.is_empty() && remote_port > 0 {
+                if let Ok(addr) =
+                    format!("{}:{}", remote_ip, remote_port).parse::<std::net::SocketAddr>()
+                {
+                    for pkt in &pkts {
+                        let _ = sock.send_to(&pkt.to_bytes(), addr);
                     }
                 }
             }
@@ -1588,12 +1651,25 @@ impl Call {
             if let Some(m) = sess.audio_media() {
                 inner.remote_port = m.port;
             }
-            let remote_audio: &[i32] = sess
+            // Exclude PT 101 (telephone-event) when picking the audio codec —
+            // matches the filter in `negotiate_codec` so both negotiation
+            // sites pick a real media codec, never telephone-event.
+            let remote_audio: Vec<i32> = sess
                 .audio_media()
-                .map(|m| m.codecs.as_slice())
-                .unwrap_or(&[]);
-            let prefs_for_negotiate = Self::resolve_codec_prefs(&inner);
-            let pt = sdp::negotiate_codec(prefs_for_negotiate, remote_audio);
+                .map(|m| {
+                    m.codecs
+                        .iter()
+                        .copied()
+                        .filter(|&p| p != PT_TELEPHONE_EVENT)
+                        .collect()
+                })
+                .unwrap_or_default();
+            let audio_prefs: Vec<i32> = Self::resolve_codec_prefs(&inner)
+                .iter()
+                .copied()
+                .filter(|&p| p != PT_TELEPHONE_EVENT)
+                .collect();
+            let pt = sdp::negotiate_codec(&audio_prefs, &remote_audio);
             if pt >= 0 {
                 if let Some(c) = Codec::from_payload_type(pt) {
                     inner.codec = c;
@@ -2896,15 +2972,86 @@ mod tests {
     }
 
     #[test]
-    fn send_dtmf_both_mode_uses_rfc4733() {
-        // Both mode should use RFC 4733 (RTP), not SIP INFO.
+    fn send_dtmf_both_mode_always_sends_sip_info() {
+        // Both mode sends SIP INFO unconditionally (for remotes that strip
+        // RFC 4733 RTP). RFC 4733 RTP is also sent when PT 101 was negotiated,
+        // but with no remote SDP set there's no negotiation → only SIP INFO.
         let dlg = Arc::new(crate::mock::dialog::MockDialog::new());
         let call = Call::new_inbound(Arc::clone(&dlg) as Arc<dyn Dialog>);
         call.set_dtmf_mode(crate::config::DtmfMode::Both);
         call.accept().unwrap();
-        // Without an RTP socket it will fail, but it should NOT use SIP INFO.
-        let _ = call.send_dtmf("1");
-        assert!(dlg.info_dtmf_sent().is_empty());
+        call.send_dtmf("1").unwrap();
+        let sent = dlg.info_dtmf_sent();
+        assert_eq!(sent.len(), 1);
+        assert_eq!(sent[0].0, "1");
+    }
+
+    #[test]
+    fn send_dtmf_rfc4733_without_negotiation_errors() {
+        // In Rfc4733 mode, sending DTMF before PT 101 is negotiated must
+        // surface Error::DtmfNotNegotiated — not silently drop the digit.
+        let call = Call::new_inbound(mock_dlg());
+        call.set_dtmf_mode(crate::config::DtmfMode::Rfc4733);
+        call.accept().unwrap();
+        match call.send_dtmf("1") {
+            Err(Error::DtmfNotNegotiated) => {}
+            other => panic!("expected DtmfNotNegotiated, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn send_dtmf_rfc4733_outbound_without_negotiation_errors() {
+        // Outbound path: the common integration-test shape is
+        // `new_outbound → simulate_response(200)` without the caller ever
+        // wiring up remote SDP. `send_dtmf` in Rfc4733 mode must still surface
+        // DtmfNotNegotiated rather than silently no-op.
+        let call = Call::new_outbound(mock_dlg(), DialOptions::default());
+        call.set_dtmf_mode(crate::config::DtmfMode::Rfc4733);
+        call.simulate_response(200, "OK");
+        match call.send_dtmf("1") {
+            Err(Error::DtmfNotNegotiated) => {}
+            other => panic!("expected DtmfNotNegotiated, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn send_dtmf_rfc4733_after_negotiation_succeeds() {
+        // When the remote SDP advertises PT 101, Rfc4733 DTMF should succeed
+        // (the call won't actually send on the wire without a real socket,
+        // but send_dtmf returns Ok).
+        let call = Call::new_inbound(mock_dlg());
+        call.set_dtmf_mode(crate::config::DtmfMode::Rfc4733);
+        call.accept().unwrap();
+        let remote_sdp = "v=0\r\n\
+            o=- 0 0 IN IP4 127.0.0.1\r\n\
+            s=-\r\n\
+            c=IN IP4 127.0.0.1\r\n\
+            t=0 0\r\n\
+            m=audio 4000 RTP/AVP 0 101\r\n\
+            a=rtpmap:0 PCMU/8000\r\n\
+            a=rtpmap:101 telephone-event/8000\r\n";
+        call.set_remote_sdp(remote_sdp);
+        call.send_dtmf("1").unwrap();
+    }
+
+    #[test]
+    fn send_dtmf_both_mode_after_negotiation_sends_both() {
+        // With PT 101 negotiated, Both mode sends RFC 4733 RTP **and** SIP INFO.
+        let dlg = Arc::new(crate::mock::dialog::MockDialog::new());
+        let call = Call::new_inbound(Arc::clone(&dlg) as Arc<dyn Dialog>);
+        call.set_dtmf_mode(crate::config::DtmfMode::Both);
+        call.accept().unwrap();
+        let remote_sdp = "v=0\r\n\
+            o=- 0 0 IN IP4 127.0.0.1\r\n\
+            s=-\r\n\
+            c=IN IP4 127.0.0.1\r\n\
+            t=0 0\r\n\
+            m=audio 4000 RTP/AVP 0 101\r\n\
+            a=rtpmap:0 PCMU/8000\r\n\
+            a=rtpmap:101 telephone-event/8000\r\n";
+        call.set_remote_sdp(remote_sdp);
+        call.send_dtmf("1").unwrap();
+        assert_eq!(dlg.info_dtmf_sent().len(), 1);
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -435,6 +435,12 @@ pub struct DialOptions {
     /// Video codecs in preference order. Defaults to `[H264, VP8]` when
     /// `video` is enabled. Only used when `video` is `true`.
     pub video_codecs: Vec<VideoCodec>,
+    /// Override the local IP advertised in SDP for this call only.
+    /// Takes precedence over [`Config::local_ip`](Config::local_ip). Useful on
+    /// multi-homed hosts when individual calls need different source-routable
+    /// addresses. `None` falls through to `Config::local_ip` → STUN-mapped
+    /// address → route-lookup heuristic.
+    pub rtp_address: Option<String>,
 }
 
 impl Default for DialOptions {
@@ -448,6 +454,7 @@ impl Default for DialOptions {
             auth: None,
             video: false,
             video_codecs: Vec::new(),
+            rtp_address: None,
         }
     }
 }
@@ -518,6 +525,12 @@ impl DialOptionsBuilder {
     /// Sets the preferred video codecs (default: `[H264, VP8]`).
     pub fn video_codecs(mut self, codecs: Vec<VideoCodec>) -> Self {
         self.opts.video_codecs = codecs;
+        self
+    }
+
+    /// Overrides the local IP advertised in SDP for this call only.
+    pub fn rtp_address(mut self, ip: &str) -> Self {
+        self.opts.rtp_address = Some(ip.into());
         self
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -57,8 +57,11 @@ pub struct Config {
     /// Opt-in so existing deployments see no change.
     pub nat: bool,
 
-    /// Override the local IP advertised in SDP/Via/Contact.
-    /// If empty, the address is auto-detected.
+    /// Override the local IP advertised in the SDP `c=` line. If empty, the
+    /// address is auto-detected. Scope is SDP-only — `Contact` and `Via` stay
+    /// anchored to the bound SIP socket. See
+    /// [`DialOptions::rtp_address`](crate::config::DialOptions::rtp_address)
+    /// for a per-call override and for the rationale.
     pub local_ip: String,
     /// Minimum port in the RTP port range (0 = OS-assigned).
     ///
@@ -442,13 +445,14 @@ pub struct DialOptions {
     /// `Config::local_ip` → STUN-mapped address → route-lookup heuristic.
     ///
     /// **Scope is intentionally SDP-only.** This does **not** modify the SIP
-    /// `Contact` header or `Via` — those stay on the socket the SIP client
-    /// actually bound. Overriding Contact would break REGISTER-behind-NAT in
-    /// Docker-bridge setups, where the SIP port is ephemeral and not
-    /// port-forwarded, so the REGISTER `rport` source-address fallback is the
-    /// only way inbound INVITEs find you. (See xphone-go `WithRTPAddress`
-    /// incident — that option conflated media and signaling scopes and broke
-    /// exactly this scenario.)
+    /// `Contact` header or `Via` — those stay anchored to the socket the SIP
+    /// client actually bound. Rewriting Contact with a routable-looking IP but
+    /// the ephemeral bound SIP port breaks inbound signaling behind NAT: the
+    /// port isn't forwarded, so registrars that trust a plausible-looking
+    /// Contact over their own NAT learning (rport / `received` on REGISTER,
+    /// keepalives) send INVITEs into the void. xphone-go's `WithRTPAddress`
+    /// conflated these scopes and tripped exactly this failure in
+    /// Docker-bridge deployments — keeping the scope SDP-only avoids it.
     pub rtp_address: Option<String>,
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -435,11 +435,20 @@ pub struct DialOptions {
     /// Video codecs in preference order. Defaults to `[H264, VP8]` when
     /// `video` is enabled. Only used when `video` is `true`.
     pub video_codecs: Vec<VideoCodec>,
-    /// Override the local IP advertised in SDP for this call only.
-    /// Takes precedence over [`Config::local_ip`](Config::local_ip). Useful on
-    /// multi-homed hosts when individual calls need different source-routable
-    /// addresses. `None` falls through to `Config::local_ip` → STUN-mapped
-    /// address → route-lookup heuristic.
+    /// Override the local IP advertised in SDP (the `c=` line) for this call
+    /// only. Takes precedence over [`Config::local_ip`](Config::local_ip).
+    /// Useful on multi-homed hosts when individual calls need different
+    /// source-routable media addresses. `None` falls through to
+    /// `Config::local_ip` → STUN-mapped address → route-lookup heuristic.
+    ///
+    /// **Scope is intentionally SDP-only.** This does **not** modify the SIP
+    /// `Contact` header or `Via` — those stay on the socket the SIP client
+    /// actually bound. Overriding Contact would break REGISTER-behind-NAT in
+    /// Docker-bridge setups, where the SIP port is ephemeral and not
+    /// port-forwarded, so the REGISTER `rport` source-address fallback is the
+    /// only way inbound INVITEs find you. (See xphone-go `WithRTPAddress`
+    /// incident — that option conflated media and signaling scopes and broke
+    /// exactly this scenario.)
     pub rtp_address: Option<String>,
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -35,6 +35,12 @@ pub enum Error {
     /// The supplied character is not a valid DTMF digit (0-9, *, #, A-D).
     #[error("xphone: invalid DTMF digit")]
     InvalidDtmfDigit,
+    /// `send_dtmf` called in [`DtmfMode::Rfc4733`](crate::config::DtmfMode)
+    /// but RFC 4733 telephone-event (PT 101) was not negotiated with the
+    /// remote. Switch to [`DtmfMode::SipInfo`](crate::config::DtmfMode) or
+    /// [`DtmfMode::Both`](crate::config::DtmfMode) to fall back to SIP INFO.
+    #[error("xphone: RFC 4733 DTMF not negotiated with remote")]
+    DtmfNotNegotiated,
     /// Mute was requested but the call is already muted.
     #[error("xphone: already muted")]
     AlreadyMuted,

--- a/src/phone.rs
+++ b/src/phone.rs
@@ -304,14 +304,43 @@ impl Phone {
         };
 
         // Allocate RTP port and build SDP offer.
-        // Use STUN-mapped IP from transport if available.
-        let local_ip = if !self.cfg.local_ip.is_empty() {
+        // Precedence: DialOptions::rtp_address → Config::local_ip → STUN-mapped
+        // advertised address → route-lookup heuristic.
+        let local_ip = if let Some(ref addr) = opts.rtp_address {
+            addr.clone()
+        } else if !self.cfg.local_ip.is_empty() {
             self.cfg.local_ip.clone()
         } else if let Some(addr) = tr.advertised_addr() {
             addr.ip().to_string()
         } else {
             local_ip_for(&self.cfg.host)
         };
+
+        // Resolve audio codec list: DialOptions::codec_override →
+        // Config::codec_prefs → DEFAULT_CODEC_PREFS. Auto-inject PT 101 when
+        // DTMF mode is Rfc4733 or Both so the remote knows we accept RFC 4733
+        // digits.
+        let mut audio_codecs: Vec<i32> = if !opts.codec_override.is_empty() {
+            opts.codec_override
+                .iter()
+                .map(|c| c.payload_type())
+                .collect()
+        } else if !self.cfg.codec_prefs.is_empty() {
+            self.cfg
+                .codec_prefs
+                .iter()
+                .map(|c| c.payload_type())
+                .collect()
+        } else {
+            crate::call::DEFAULT_CODEC_PREFS.to_vec()
+        };
+        if matches!(
+            self.cfg.dtmf_mode,
+            crate::config::DtmfMode::Rfc4733 | crate::config::DtmfMode::Both
+        ) && !audio_codecs.contains(&crate::call::PT_TELEPHONE_EVENT)
+        {
+            audio_codecs.push(crate::call::PT_TELEPHONE_EVENT);
+        }
         let (rtp_socket, rtp_port) = {
             let (sock, port) =
                 crate::media::listen_rtp_port(self.cfg.rtp_port_min, self.cfg.rtp_port_max)?;
@@ -355,7 +384,7 @@ impl Phone {
                 (Some(audio_key), Some(video_key)) => crate::sdp::build_offer_video_srtp(
                     &local_ip,
                     rtp_port,
-                    &[8, 0, 9, 101],
+                    &audio_codecs,
                     video_rtp_port,
                     &video_codecs,
                     crate::sdp::DIR_SEND_RECV,
@@ -365,7 +394,7 @@ impl Phone {
                 _ => crate::sdp::build_offer_video(
                     &local_ip,
                     rtp_port,
-                    &[8, 0, 9, 101],
+                    &audio_codecs,
                     video_rtp_port,
                     &video_codecs,
                     crate::sdp::DIR_SEND_RECV,
@@ -375,7 +404,7 @@ impl Phone {
             crate::sdp::build_offer_srtp(
                 &local_ip,
                 rtp_port,
-                &[8, 0, 9, 101],
+                &audio_codecs,
                 crate::sdp::DIR_SEND_RECV,
                 key,
             )
@@ -383,7 +412,7 @@ impl Phone {
             crate::sdp::build_offer(
                 &local_ip,
                 rtp_port,
-                &[8, 0, 9, 101],
+                &audio_codecs,
                 crate::sdp::DIR_SEND_RECV,
             )
         };
@@ -1261,6 +1290,113 @@ mod tests {
         assert!(
             sdp.contains("c=IN IP4 10.0.0.99"),
             "SDP should use explicit local_ip over STUN, got: {}",
+            sdp
+        );
+    }
+
+    #[test]
+    fn dial_rtp_address_overrides_config_local_ip() {
+        let tr = Arc::new(MockTransport::new());
+        tr.respond_with(200, "OK"); // REGISTER
+
+        let mut cfg = test_cfg();
+        cfg.local_ip = "10.0.0.99".into();
+        let phone = Phone::new(cfg);
+        phone.connect_with_transport(Arc::clone(&tr) as Arc<dyn SipTransport>);
+
+        tr.respond_with(200, "OK"); // INVITE
+        let opts = crate::config::DialOptionsBuilder::new()
+            .rtp_address("192.168.1.50")
+            .build();
+        let call = phone.dial("sip:1002@pbx.local", opts).unwrap();
+
+        let sdp = call.local_sdp();
+        assert!(
+            sdp.contains("c=IN IP4 192.168.1.50"),
+            "DialOptions::rtp_address should win over Config::local_ip, got: {}",
+            sdp
+        );
+    }
+
+    #[test]
+    fn dial_codec_override_appears_in_sdp() {
+        let tr = Arc::new(MockTransport::new());
+        tr.respond_with(200, "OK"); // REGISTER
+
+        let phone = Phone::new(test_cfg());
+        phone.connect_with_transport(Arc::clone(&tr) as Arc<dyn SipTransport>);
+
+        tr.respond_with(200, "OK"); // INVITE
+        let opts = crate::config::DialOptionsBuilder::new()
+            .codec_override(vec![crate::types::Codec::G722])
+            .build();
+        let call = phone.dial("sip:1002@pbx.local", opts).unwrap();
+
+        // G.722 must be offered; PCMU/PCMA must NOT be (override narrowed).
+        // PT 101 is still auto-injected because DtmfMode defaults to Rfc4733.
+        let sdp = call.local_sdp();
+        let audio_line = sdp.lines().find(|l| l.starts_with("m=audio")).unwrap_or("");
+        assert!(
+            audio_line.contains(" 9 ") || audio_line.ends_with(" 9"),
+            "G.722 (PT 9) should be in m=audio, got: {}",
+            audio_line
+        );
+        assert!(
+            !audio_line.contains(" 0 ") && !audio_line.ends_with(" 0"),
+            "PCMU (PT 0) must not appear when override excludes it, got: {}",
+            audio_line
+        );
+        assert!(
+            audio_line.contains(" 101 ") || audio_line.ends_with(" 101"),
+            "PT 101 should be auto-injected for default Rfc4733 DTMF, got: {}",
+            audio_line
+        );
+    }
+
+    #[test]
+    fn dial_auto_injects_pt_101_when_rfc4733() {
+        let tr = Arc::new(MockTransport::new());
+        tr.respond_with(200, "OK"); // REGISTER
+
+        let mut cfg = test_cfg();
+        cfg.codec_prefs = vec![crate::types::Codec::PCMU];
+        cfg.dtmf_mode = crate::config::DtmfMode::Rfc4733;
+        let phone = Phone::new(cfg);
+        phone.connect_with_transport(Arc::clone(&tr) as Arc<dyn SipTransport>);
+
+        tr.respond_with(200, "OK"); // INVITE
+        let call = phone
+            .dial("sip:1002@pbx.local", DialOptions::default())
+            .unwrap();
+
+        let sdp = call.local_sdp();
+        assert!(
+            sdp.contains("a=rtpmap:101 telephone-event"),
+            "PT 101 should be auto-injected when DtmfMode is Rfc4733, got: {}",
+            sdp
+        );
+    }
+
+    #[test]
+    fn dial_does_not_inject_pt_101_for_sip_info_mode() {
+        let tr = Arc::new(MockTransport::new());
+        tr.respond_with(200, "OK"); // REGISTER
+
+        let mut cfg = test_cfg();
+        cfg.codec_prefs = vec![crate::types::Codec::PCMU];
+        cfg.dtmf_mode = crate::config::DtmfMode::SipInfo;
+        let phone = Phone::new(cfg);
+        phone.connect_with_transport(Arc::clone(&tr) as Arc<dyn SipTransport>);
+
+        tr.respond_with(200, "OK"); // INVITE
+        let call = phone
+            .dial("sip:1002@pbx.local", DialOptions::default())
+            .unwrap();
+
+        let sdp = call.local_sdp();
+        assert!(
+            !sdp.contains("telephone-event"),
+            "PT 101 should NOT be injected when DtmfMode is SipInfo, got: {}",
             sdp
         );
     }

--- a/src/sip/ua.rs
+++ b/src/sip/ua.rs
@@ -80,6 +80,14 @@ impl SipUA {
         });
 
         let client_cfg = ClientConfig {
+            // Intentionally NOT plumbed from `Config::local_ip` / any
+            // `rtp_address` override. Keep Contact/Via anchored to the socket
+            // the OS actually bound; media-side overrides (SDP `c=`) happen at
+            // SDP build time, not here. Mixing them would break REGISTER
+            // behind NAT — the server's source-address fallback (via rport +
+            // keepalive) is what makes inbound INVITEs reach ephemeral ports
+            // that are not explicitly forwarded. See xphone-go's
+            // `WithRTPAddress` incident.
             local_addr: "0.0.0.0:0".into(),
             server_addr,
             username: cfg.username.clone(),

--- a/src/sip/ua.rs
+++ b/src/sip/ua.rs
@@ -81,13 +81,11 @@ impl SipUA {
 
         let client_cfg = ClientConfig {
             // Intentionally NOT plumbed from `Config::local_ip` / any
-            // `rtp_address` override. Keep Contact/Via anchored to the socket
-            // the OS actually bound; media-side overrides (SDP `c=`) happen at
-            // SDP build time, not here. Mixing them would break REGISTER
-            // behind NAT — the server's source-address fallback (via rport +
-            // keepalive) is what makes inbound INVITEs reach ephemeral ports
-            // that are not explicitly forwarded. See xphone-go's
-            // `WithRTPAddress` incident.
+            // `rtp_address` override. Contact/Via must stay on the socket the
+            // OS actually bound; media-side overrides (SDP `c=`) happen at
+            // SDP build time, not here. Plumbing a user-supplied IP here
+            // would rewrite Contact with the ephemeral bound SIP port (not
+            // NAT-forwarded), silently breaking inbound signaling behind NAT.
             local_addr: "0.0.0.0:0".into(),
             server_addr,
             username: cfg.username.clone(),

--- a/src/types.rs
+++ b/src/types.rs
@@ -457,6 +457,9 @@ pub enum Codec {
     G722 = 9,
     /// G.729 (payload type 18).
     G729 = 18,
+    /// RFC 4733 telephone-event / DTMF (payload type 101). Not a media codec;
+    /// advertise it alongside audio codecs to negotiate out-of-band DTMF.
+    TelephoneEvent = 101,
     /// Opus (payload type 111).
     Opus = 111,
 }
@@ -474,6 +477,7 @@ impl Codec {
             8 => Some(Codec::PCMA),
             9 => Some(Codec::G722),
             18 => Some(Codec::G729),
+            101 => Some(Codec::TelephoneEvent),
             111 => Some(Codec::Opus),
             _ => None,
         }
@@ -487,6 +491,7 @@ impl fmt::Display for Codec {
             Codec::PCMA => write!(f, "PCMA"),
             Codec::G722 => write!(f, "G722"),
             Codec::G729 => write!(f, "G729"),
+            Codec::TelephoneEvent => write!(f, "telephone-event"),
             Codec::Opus => write!(f, "Opus"),
         }
     }


### PR DESCRIPTION
## Summary

Closes #63, #64, #65. Three connected DTMF/media-path fixes.

### #63 — DTMF SDP & negotiation

- `DialOptions::codec_override` is now actually honoured. Previously the field existed and the builder accepted it, but `Phone::dial` ignored it and built every SDP offer from a hardcoded `[8, 0, 9, 101]` list.
- Exported `Codec::TelephoneEvent` (PT 101) — previously callers couldn't include telephone-event via the public API.
- PT 101 is now auto-injected into outbound SDP when `DtmfMode ∈ {Rfc4733, Both}` and the resolved codec list doesn't already include it. Removes the classic "I narrowed my codecs and DTMF broke" foot-gun.
- `Call::send_dtmf` tracks whether PT 101 was negotiated on both sides. In `Rfc4733` mode it surfaces `Error::DtmfNotNegotiated` rather than silently writing RTP into the void.

### #64 — `DtmfMode::Both` really means both

- `DtmfMode::Both` now sends RFC 4733 RTP (when negotiated) **and** SIP INFO on every digit. Previously `Both` was a misnomer that only sent RTP. Matches pjsua / FreeSWITCH / Asterisk convention. The "both" contract holds even when RTP send fails (warning logged, INFO still fires).
- The test `send_dtmf_both_mode_uses_rfc4733` which codified the wrong behavior was replaced with `send_dtmf_both_mode_always_sends_sip_info` + coverage of the full double-send path.

### #65 — per-call advertised IP

- Added `DialOptions::rtp_address` + builder method. Takes precedence over `Config::local_ip`. Resolution: `opts.rtp_address` → `cfg.local_ip` → STUN → `local_ip_for()` heuristic. Useful on multi-homed hosts.

## Breaking changes

Both surface in `CHANGELOG.md` under `[Unreleased]`:

- `Error::DtmfNotNegotiated` is a new error variant. Callers matching the error enum may need to add an arm.
- `DtmfMode::Both` now double-sends. Well-behaved remotes may double-report digits. Switch to `Rfc4733` or `SipInfo` if single-transport is required.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` — 881 total (850 unit + 12 fakepbx + 11 server + 2 doctest + 6 others), up from 874
- [x] New tests cover: `codec_override` respected, PT 101 auto-injected in Rfc4733/Both, PT 101 NOT injected in SipInfo, `rtp_address` precedence, `DtmfNotNegotiated` fires (inbound + outbound), `Both` mode always sends SIP INFO, full Both double-send after negotiation.
- [ ] End-to-end verification against LAN PBX is recommended but not required for merge — `rtp_address` specifically unblocks that kind of verification on multi-homed dev setups.

## Review follow-ups applied

Findings from the 6-way review that were addressed in-PR:
- Unified `DEFAULT_CODEC_PREFS` between `call.rs` and `phone.rs` (phone.rs was silently dropping Opus from the fallback).
- `Both` mode no longer short-circuits SIP INFO on RTP-send error.
- Reinvite-path codec negotiation now filters PT 101 consistently with the initial negotiation.
- Added `PT_TELEPHONE_EVENT` constant to replace the magic number.
- Added outbound-path test for `DtmfNotNegotiated` (prior test only covered inbound).

## Out of scope (future work)

- RTP DTMF encoder still uses `ts=0, seq=0, ssrc=0` — pre-existing.
- Dynamic PT for telephone-event (non-101 values) — pre-existing.
- `Config::codec_prefs` → `Call::codec_prefs` propagation — orthogonal architectural gap.
- Answer-side edge case (remote offers only PT 101 → answer has no audio codec) — theoretical.