### PR TITLE
Tighten CI CHANGELOG check to validate content

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,12 +19,21 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Check CHANGELOG.md was updated
+      - name: Check CHANGELOG.md has a new entry
         run: |
-          if git diff --name-only origin/main...HEAD | grep -q '^CHANGELOG.md$'; then
-            echo "CHANGELOG.md updated"
-          else
+          DIFF=$(git diff origin/main...HEAD -- CHANGELOG.md)
+          if [ -z "$DIFF" ]; then
             echo "::error::CHANGELOG.md was not updated. Please add an entry describing your changes."
+            exit 1
+          fi
+          # Accept either: a new "## [X.Y.Z] - YYYY-MM-DD" section (release PRs)
+          # or a new "- " bullet (normal feature/fix PRs under [Unreleased]).
+          if echo "$DIFF" | grep -qE '^\+## \[[0-9]+\.[0-9]+\.[0-9]+\]'; then
+            echo "CHANGELOG: new version section detected (release PR)"
+          elif echo "$DIFF" | grep -qE '^\+- '; then
+            echo "CHANGELOG: new bullet added"
+          else
+            echo "::error::CHANGELOG.md was touched but has no new '- ' bullet under [Unreleased] or new '## [X.Y.Z]' section. Add a meaningful entry describing your changes."
             exit 1
           fi
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ All notable changes to this project will be documented in this file.
 - **BREAKING: `Call::send_dtmf` now returns `Err(Error::DtmfNotNegotiated)`** in `DtmfMode::Rfc4733` when PT 101 was not negotiated with the remote, instead of silently writing RTP packets into the void. Add a match arm to catch this error, or switch to `DtmfMode::Both` for automatic SIP INFO fallback. (xphone-rust#63)
 - **BREAKING: `DtmfMode::Both` now actually sends both transports** — RFC 4733 RTP (when negotiated) **and** SIP INFO on every digit. Previously `Both` was a misnomer: it sent RTP only and merely *accepted* SIP INFO on inbound. Matches pjsua / FreeSWITCH / Asterisk convention and makes middlebox-stripped DTMF self-healing. Well-behaved remotes may now double-report digits in `Both` mode — switch to `Rfc4733` or `SipInfo` if single-transport is required. (xphone-rust#64)
 
+### Internal
+
+- CI CHANGELOG check now validates content, not just that the file was touched. Passes on either a new `- ` bullet under `[Unreleased]` (normal PRs) or a new `## [X.Y.Z]` section (release PRs); fails on whitespace-only / comment-only edits that don't introduce a meaningful entry.
+
 ## [0.5.0] - 2026-04-22
 
 ### Added


### PR DESCRIPTION
## Summary

The old CHANGELOG check only verified `CHANGELOG.md` was in the PR diff — whitespace-only or comment-only edits passed. Tighten it to require either:

- a new `- ` bullet (normal PRs)
- a new `## [X.Y.Z]` section heading (release PRs)

Falls back to the original \"not updated\" error when the file is untouched.

## Test plan

- [x] Local regex validation on the current PR's own CHANGELOG addition → `PASS: new bullet`
- [x] Simulated release-PR diff → `PASS: version section`
- [x] Simulated whitespace-only diff → `FAIL as expected`
- [ ] This PR's CI run dogfoods the check (the `### Internal` CHANGELOG entry is the test input)

## Known limitations

Flagged by review, accepted as-is:
- Reformatting an existing bullet passes (hard to distinguish from a genuine add without semantic diff; legitimate typo fixes should pass too).
- Hardcoded `origin/main` base ref. All PRs target main per project policy; stacked-PR deltas still contain the parent's CHANGELOG additions.

## Follow-up triggers

If any of these start happening, revisit:
- PRs targeting non-main bases other than stacked-on-open-PR
- Pre-release version schemes (`-rc.1`, `v1.2.3` prefix)