### PR TITLE
perf(jitter): sorted insert in push, drop per-pop sort

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ All notable changes to this project will be documented in this file.
 - **BREAKING: `Call::send_dtmf` now returns `Err(Error::DtmfNotNegotiated)`** in `DtmfMode::Rfc4733` when PT 101 was not negotiated with the remote, instead of silently writing RTP packets into the void. Add a match arm to catch this error, or switch to `DtmfMode::Both` for automatic SIP INFO fallback. (xphone-rust#63)
 - **BREAKING: `DtmfMode::Both` now actually sends both transports** — RFC 4733 RTP (when negotiated) **and** SIP INFO on every digit. Previously `Both` was a misnomer: it sent RTP only and merely *accepted* SIP INFO on inbound. Matches pjsua / FreeSWITCH / Asterisk convention and makes middlebox-stripped DTMF self-healing. Well-behaved remotes may now double-report digits in `Both` mode — switch to `Rfc4733` or `SipInfo` if single-transport is required. (xphone-rust#64)
 
+### Performance
+
+- **`JitterBuffer` no longer re-sorts on every `pop()` / `flush()`.** Buffer is kept in sequence order via sorted insert in `push()` (`Vec::binary_search_by` + `Vec::insert`); `pop()` and `flush()` drop the per-call sort entirely. The remaining work is a small vec memmove (`Vec::remove(0)` on pop, `drain(..)` on flush) over a few dozen entries — well below the prior O(N log N) cost. At telephony cadence (50 pop/sec/stream) the previous sort dominated CPU on busy hosts — pprof on the Go port (xphone-go#114) showed ~20% of total CPU spent in the equivalent path with ~30 concurrent G.711 calls. Behavior preserved across reorder, dedup, depth, and 16-bit wraparound (existing tests unchanged). (xphone-go#114 parity)
+
 ### Internal
 
 - CI CHANGELOG check now validates content, not just that the file was touched. Passes on either a new `- ` bullet under `[Unreleased]` (normal PRs) or a new `## [X.Y.Z]` section (release PRs); fails on whitespace-only / comment-only edits that don't introduce a meaningful entry.

--- a/src/jitter.rs
+++ b/src/jitter.rs
@@ -1,3 +1,4 @@
+use std::cmp::Ordering;
 use std::time::{Duration, Instant};
 
 use parking_lot::Mutex;
@@ -16,16 +17,21 @@ fn seq_less(a: u16, b: u16) -> bool {
     diff > 0 && diff < 0x8000
 }
 
-fn sort_entries(entries: &mut [JitterEntry]) {
-    entries.sort_by(|a, b| {
-        if seq_less(a.pkt.header.sequence_number, b.pkt.header.sequence_number) {
-            std::cmp::Ordering::Less
-        } else if a.pkt.header.sequence_number == b.pkt.header.sequence_number {
-            std::cmp::Ordering::Equal
-        } else {
-            std::cmp::Ordering::Greater
-        }
-    });
+/// Wraparound-aware ordering for RTP sequence numbers.
+///
+/// Defines a strict order only when all compared values lie within a window
+/// of less than 32768 sequence numbers — true for any sane jitter buffer
+/// (telephony depths are tens of packets) but worth being explicit about
+/// since [`Vec::binary_search_by`] relies on the slice being totally ordered
+/// under the comparator.
+fn seq_cmp(a: u16, b: u16) -> Ordering {
+    if a == b {
+        Ordering::Equal
+    } else if seq_less(a, b) {
+        Ordering::Less
+    } else {
+        Ordering::Greater
+    }
 }
 
 /// Reorders and deduplicates incoming RTP packets.
@@ -54,14 +60,22 @@ impl JitterBuffer {
     /// Adds an RTP packet to the buffer. Duplicates are dropped.
     pub fn push(&self, pkt: RtpPacket) {
         let mut inner = self.inner.lock();
-        if inner.seen.contains(&pkt.header.sequence_number) {
+        let seq = pkt.header.sequence_number;
+        if inner.seen.contains(&seq) {
             return;
         }
-        inner.seen.insert(pkt.header.sequence_number);
-        inner.entries.push(JitterEntry {
-            pkt,
-            arrival: Instant::now(),
-        });
+        inner.seen.insert(seq);
+        let pos = inner
+            .entries
+            .binary_search_by(|e| seq_cmp(e.pkt.header.sequence_number, seq))
+            .unwrap_or_else(|p| p);
+        inner.entries.insert(
+            pos,
+            JitterEntry {
+                pkt,
+                arrival: Instant::now(),
+            },
+        );
     }
 
     /// Returns the next packet in sequence order if its arrival time exceeds
@@ -71,8 +85,6 @@ impl JitterBuffer {
         if inner.entries.is_empty() {
             return None;
         }
-
-        sort_entries(&mut inner.entries);
 
         let now = Instant::now();
         if now.duration_since(inner.entries[0].arrival) >= inner.depth {
@@ -90,8 +102,6 @@ impl JitterBuffer {
         if inner.entries.is_empty() {
             return Vec::new();
         }
-
-        sort_entries(&mut inner.entries);
 
         let pkts = inner.entries.drain(..).map(|e| e.pkt).collect();
         inner.seen.clear();


### PR DESCRIPTION
## Summary

- `JitterBuffer::pop()` and `flush()` ran `sort_by` over the full entries `Vec` on every call. At 50 pop/sec/stream this dominated CPU.
- Keep the buffer in sequence order via sorted insert in `push()` using `Vec::binary_search_by` + `Vec::insert`. `pop()` and `flush()` drop the sort entirely.
- Parity with xphone-go#114 — pprof on the Go port showed ~20% of total CPU in the equivalent path under ~30 concurrent G.711 calls.

## Notes on correctness

- The wraparound-aware comparator (`seq_cmp`) is a partial order that behaves as a total order on any window < 32768 sequence numbers, which trivially holds for telephony jitter depths (tens of packets). Documented inline on `seq_cmp`.
- `Vec::insert(pos, ...)` is safe: `binary_search_by` returns `pos ∈ [0, len]`.
- `Vec::remove(0)` is guarded by the `is_empty()` check.
- `seen` HashSet and `entries` stay in lockstep — same invariants as before.

## Test plan

- [x] `cargo fmt && cargo clippy -- -D warnings` clean
- [x] `cargo test` — 850 lib + 12 fakepbx + 11 integration tests pass
- [x] `jitter::tests::sequence_wrap_around` still covers the 65534/65535/0/1 reorder case under the new sorted-insert path
- [x] `jitter::tests::dedup` confirms `seen` dedup still suppresses duplicates