### PR TITLE
chore: release 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-05-13
+
 ### Added
 
 - **`Codec::TelephoneEvent`** (PT 101) exported from `crate::types`. Previously PT 101 was hardcoded in SDP offers but not representable through the public `Codec` enum — callers could not include it via `DialOptions::codec_override`. (xphone-rust#63)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2669,7 +2669,7 @@ checksum = "3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f"
 
 [[package]]
 name = "xphone"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "aes",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xphone"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 rust-version = "1.87"
 description = "SIP telephony library with event-driven API — handles SIP signaling, RTP media, codecs, and call state"

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-xphone = "0.4"
+xphone = "0.6"
 ```
 
 Requires Rust 1.87+.


### PR DESCRIPTION
## Summary

Release **0.6.0** — minor bump because two BREAKING changes already accumulated in `[Unreleased]` from PRs #63 and #64.

### Highlights since 0.5.0

- **perf**: `JitterBuffer` sorted-insert in `push()`, dropping per-pop O(N log N) sort. xphone-go#114 parity — pprof on the Go port showed ~20% of total CPU spent in the equivalent path under ~30 concurrent G.711 calls. (#68)
- **feat**: `Codec::TelephoneEvent` (PT 101) exported. (#63)
- **feat**: `DialOptions::rtp_address` — per-call SDP `c=` override (SDP-only scope, doesn't touch Contact/Via). (#65)
- **fix**: `DialOptions::codec_override` is now actually honoured by `Phone::dial`. (#63)
- **feat**: DTMF PT 101 auto-injected into outbound SDP when `DtmfMode` is `Rfc4733` or `Both`. (#63)
- **BREAKING**: `Call::send_dtmf` returns `Err(Error::DtmfNotNegotiated)` in `DtmfMode::Rfc4733` when PT 101 wasn't negotiated. (#63)
- **BREAKING**: `DtmfMode::Both` now sends both RFC 4733 RTP **and** SIP INFO outbound (previously RTP-only outbound). (#64)
- CI CHANGELOG check validates content, not just file touch. (#67)

Full details in `CHANGELOG.md`.

### Files

- `Cargo.toml` — 0.5.0 → 0.6.0
- `Cargo.lock` — synced (per project policy)
- `README.md` — quick-start pin "0.4" → "0.6"
- `CHANGELOG.md` — `[Unreleased]` items moved under `## [0.6.0] - 2026-05-13`

## Test plan

- [x] `cargo fmt && cargo clippy -- -D warnings` clean
- [x] `cargo test` — 850 lib + 12 fakepbx + 11 integration tests pass
- [ ] After merge: tag `v0.6.0` and push (triggers `publish.yml` → crates.io)