### PR TITLE
Jitter buffer improvement and opus fec support

### DIFF
--- a/src/codec/opus_codec.rs
+++ b/src/codec/opus_codec.rs
@@ -6,6 +6,7 @@
 
 use super::CodecProcessor;
 use opus::{Application, Channels, Decoder, Encoder};
+use std::cell::Cell;
 
 const PAYLOAD_TYPE: u8 = 111;
 const CLOCK_RATE: u32 = 48000;
@@ -16,20 +17,28 @@ const MAX_DECODE_SAMPLES: usize = 960; // 120ms at 8kHz — handles up to 60ms O
 pub struct OpusProcessor {
     enc: Encoder,
     dec: Decoder,
+    skipped: Cell<bool>,
 }
 
 impl OpusProcessor {
     pub fn new() -> Option<Self> {
-        let enc = Encoder::new(PCM_RATE, Channels::Mono, Application::Voip).ok()?;
-        let dec = Decoder::new(PCM_RATE, Channels::Mono).ok()?;
-        Some(Self { enc, dec })
+        let mut enc = Encoder::new(PCM_RATE, Channels::Mono, Application::Voip).ok()?;
+        enc.set_complexity(10).ok()?;
+        enc.set_inband_fec(true).ok()?;
+        enc.set_packet_loss_perc(25).ok()?;
+        let mut dec = Decoder::new(PCM_RATE, Channels::Mono).ok()?;
+        let skipped = Cell::new(false);
+        Some(Self { enc, dec, skipped })
     }
 }
 
 impl CodecProcessor for OpusProcessor {
     fn decode(&mut self, payload: &[u8]) -> Vec<i16> {
         let mut out = vec![0i16; MAX_DECODE_SAMPLES];
-        match self.dec.decode(payload, &mut out, false) {
+        // if previous packet is empty and current packet is not empty then fec is enabled.
+        let is_empty = payload.len() == 0;
+        let fec = self.skipped.replace(is_empty) && !is_empty;
+        match self.dec.decode(payload, &mut out, fec) {
             Ok(n) => {
                 out.truncate(n);
                 out

--- a/src/codec/opus_codec.rs
+++ b/src/codec/opus_codec.rs
@@ -23,9 +23,9 @@ pub struct OpusProcessor {
 impl OpusProcessor {
     pub fn new() -> Option<Self> {
         let mut enc = Encoder::new(PCM_RATE, Channels::Mono, Application::Voip).ok()?;
-        enc.set_complexity(10).ok()?;
-        enc.set_inband_fec(true).ok()?;
-        enc.set_packet_loss_perc(25).ok()?;
+        let _ = enc.set_complexity(10).ok()?;
+        let _ = enc.set_inband_fec(true).ok()?;
+        let _ = enc.set_packet_loss_perc(25).ok()?;
         let mut dec = Decoder::new(PCM_RATE, Channels::Mono).ok()?;
         let skipped = Cell::new(false);
         Some(Self { enc, dec, skipped })

--- a/src/jitter.rs
+++ b/src/jitter.rs
@@ -66,7 +66,7 @@ impl JitterBuffer {
             inner: Mutex::new(JitterInner {
                 depth,
                 frame,
-                last_arrival: Instant::now() - frame,
+                last_arrival: Instant::now() - depth,
                 start: Instant::now(),
                 entries: Cell::new(BTreeMap::new()),
                 last_pop: None,
@@ -111,7 +111,7 @@ impl JitterBuffer {
                     0
                 };
                 // average frame rate
-                let frame = (inner.frame * 7 + (value.arrival.duration_since(inner.last_arrival)) / (skipped as u32 + 1)) / 8 ;
+                let frame = (inner.frame * 3 + (value.arrival.duration_since(inner.last_arrival)) / (skipped as u32 + 1)) / 4;
                 inner.frame = frame;
                 inner.last_arrival = value.arrival;
                 inner.depth += frame * (skipped as u32 + 1);

--- a/src/jitter.rs
+++ b/src/jitter.rs
@@ -9,6 +9,7 @@ use crate::types::RtpPacket;
 
 struct JitterEntry {
     pkt: RtpPacket,
+    arrival: Instant,
 }
 
 /// Compares two 16-bit RTP sequence numbers with wraparound (RFC 3550).
@@ -52,6 +53,7 @@ pub struct JitterBuffer {
 struct JitterInner {
     depth: Duration,
     frame: Duration,
+    last_arrival: Instant,
     start: Instant,
     entries: Cell<BTreeMap<SeqNum, JitterEntry>>,
     last_pop: Option<SeqNum>,
@@ -64,6 +66,7 @@ impl JitterBuffer {
             inner: Mutex::new(JitterInner {
                 depth,
                 frame,
+                last_arrival: Instant::now() - frame,
                 start: Instant::now(),
                 entries: Cell::new(BTreeMap::new()),
                 last_pop: None,
@@ -71,7 +74,6 @@ impl JitterBuffer {
         }
     }
 
-    /// Adds an RTP packet to the buffer. Duplicates are dropped.
     pub fn push(&self, pkt: RtpPacket) {
         let mut inner = self.inner.lock();
         let seq = pkt.header.sequence_number;
@@ -85,7 +87,12 @@ impl JitterBuffer {
             .entries
             .get_mut()
             .entry(SeqNum(seq))
-            .or_insert(JitterEntry { pkt });
+            .or_insert(
+                JitterEntry {
+                    pkt,
+                    arrival: Instant::now(),
+                },
+            );
     }
 
     /// Returns the next packet in sequence order if its arrival time exceeds
@@ -103,7 +110,10 @@ impl JitterBuffer {
                 } else {
                     0
                 };
-                let frame = inner.frame;
+                // average frame rate
+                let frame = (inner.frame * 7 + (value.arrival.duration_since(inner.last_arrival)) / (skipped as u32 + 1)) / 8 ;
+                inner.frame = frame;
+                inner.last_arrival = value.arrival;
                 inner.depth += frame * (skipped as u32 + 1);
                 inner.last_pop = Some(key);
                 Some((value.pkt, skipped))

--- a/src/jitter.rs
+++ b/src/jitter.rs
@@ -1,4 +1,6 @@
-use std::cmp::Ordering;
+use std::cell::Cell;
+use std::cmp::{Ord, Ordering};
+use std::collections::BTreeMap;
 use std::time::{Duration, Instant};
 
 use parking_lot::Mutex;
@@ -7,7 +9,6 @@ use crate::types::RtpPacket;
 
 struct JitterEntry {
     pkt: RtpPacket,
-    arrival: Instant,
 }
 
 /// Compares two 16-bit RTP sequence numbers with wraparound (RFC 3550).
@@ -34,6 +35,15 @@ fn seq_cmp(a: u16, b: u16) -> Ordering {
     }
 }
 
+#[derive(PartialEq, Eq, PartialOrd)]
+struct SeqNum(pub u16);
+impl Ord for SeqNum {
+    #[inline]
+    fn cmp(&self, other: &SeqNum) -> Ordering {
+        seq_cmp(*(&self.0), *(&other.0))
+    }
+}
+
 /// Reorders and deduplicates incoming RTP packets.
 pub struct JitterBuffer {
     inner: Mutex<JitterInner>,
@@ -41,18 +51,22 @@ pub struct JitterBuffer {
 
 struct JitterInner {
     depth: Duration,
-    entries: Vec<JitterEntry>,
-    seen: std::collections::HashSet<u16>,
+    frame: Duration,
+    start: Instant,
+    entries: Cell<BTreeMap<SeqNum, JitterEntry>>,
+    last_pop: Option<SeqNum>,
 }
 
 impl JitterBuffer {
     /// Creates a JitterBuffer with the given playout depth.
-    pub fn new(depth: Duration) -> Self {
+    pub fn new(depth: Duration, frame: Duration) -> Self {
         JitterBuffer {
             inner: Mutex::new(JitterInner {
                 depth,
-                entries: Vec::new(),
-                seen: std::collections::HashSet::new(),
+                frame,
+                start: Instant::now(),
+                entries: Cell::new(BTreeMap::new()),
+                last_pop: None,
             }),
         }
     }
@@ -61,36 +75,41 @@ impl JitterBuffer {
     pub fn push(&self, pkt: RtpPacket) {
         let mut inner = self.inner.lock();
         let seq = pkt.header.sequence_number;
-        if inner.seen.contains(&seq) {
+        // ignore alreadly used packet
+        // use asref compare to avoid clone
+        if inner.last_pop.as_ref().is_some_and(|e| e > &SeqNum(seq)) {
             return;
         }
-        inner.seen.insert(seq);
-        let pos = inner
+        // ignore alreadly inserted packet
+        inner
             .entries
-            .binary_search_by(|e| seq_cmp(e.pkt.header.sequence_number, seq))
-            .unwrap_or_else(|p| p);
-        inner.entries.insert(
-            pos,
-            JitterEntry {
-                pkt,
-                arrival: Instant::now(),
-            },
-        );
+            .get_mut()
+            .entry(SeqNum(seq))
+            .or_insert(JitterEntry { pkt });
     }
 
     /// Returns the next packet in sequence order if its arrival time exceeds
     /// the jitter depth, or `None` if no packet is ready.
-    pub fn pop(&self) -> Option<RtpPacket> {
+    pub fn pop(&self) -> Option<(RtpPacket, u16)> {
         let mut inner = self.inner.lock();
-        if inner.entries.is_empty() {
-            return None;
-        }
-
+        let depth = inner.depth;
         let now = Instant::now();
-        if now.duration_since(inner.entries[0].arrival) >= inner.depth {
-            let entry = inner.entries.remove(0);
-            inner.seen.remove(&entry.pkt.header.sequence_number);
-            Some(entry.pkt)
+        if now.duration_since(inner.start) >= depth {
+            let entry = inner.entries.get_mut().pop_first();
+            if let Some((key, value)) = entry {
+                // wait for jitter
+                let skipped: u16 = if let Some(ref last_pop) = inner.last_pop {
+                    key.0.wrapping_sub(last_pop.0) - 1
+                } else {
+                    0
+                };
+                let frame = inner.frame;
+                inner.depth += frame * (skipped as u32 + 1);
+                inner.last_pop = Some(key);
+                Some((value.pkt, skipped))
+            } else {
+                None
+            }
         } else {
             None
         }
@@ -98,14 +117,13 @@ impl JitterBuffer {
 
     /// Returns all buffered packets in sequence order and clears the buffer.
     pub fn flush(&self) -> Vec<RtpPacket> {
-        let mut inner = self.inner.lock();
-        if inner.entries.is_empty() {
-            return Vec::new();
-        }
-
-        let pkts = inner.entries.drain(..).map(|e| e.pkt).collect();
-        inner.seen.clear();
-        pkts
+        let inner = self.inner.lock();
+        inner
+            .entries
+            .replace(BTreeMap::new())
+            .into_values()
+            .map(|e| e.pkt)
+            .collect()
     }
 }
 
@@ -144,7 +162,7 @@ mod tests {
 
     #[test]
     fn in_order() {
-        let jb = JitterBuffer::new(Duration::from_millis(50));
+        let jb = JitterBuffer::new(Duration::from_millis(50), Duration::from_millis(20));
         for seq in 1..=3 {
             jb.push(make_pkt(seq));
         }
@@ -157,7 +175,7 @@ mod tests {
 
     #[test]
     fn reorder() {
-        let jb = JitterBuffer::new(Duration::from_millis(50));
+        let jb = JitterBuffer::new(Duration::from_millis(50), Duration::from_millis(20));
         jb.push(make_pkt(3));
         jb.push(make_pkt(1));
         jb.push(make_pkt(2));
@@ -171,7 +189,7 @@ mod tests {
 
     #[test]
     fn dedup() {
-        let jb = JitterBuffer::new(Duration::from_millis(50));
+        let jb = JitterBuffer::new(Duration::from_millis(50), Duration::from_millis(20));
         jb.push(make_pkt_with_payload(1, &[0xAA]));
         jb.push(make_pkt_with_payload(1, &[0xBB])); // duplicate
         jb.push(make_pkt_with_payload(2, &[0xCC]));
@@ -185,7 +203,7 @@ mod tests {
 
     #[test]
     fn configurable_depth() {
-        let short = JitterBuffer::new(Duration::from_millis(10));
+        let short = JitterBuffer::new(Duration::from_millis(10), Duration::from_millis(20));
         short.push(make_pkt(2));
         std::thread::sleep(Duration::from_millis(15));
         let pkt = short.pop();
@@ -193,9 +211,9 @@ mod tests {
             pkt.is_some(),
             "short depth should release packet after delay"
         );
-        assert_eq!(pkt.unwrap().header.sequence_number, 2);
+        assert_eq!(pkt.unwrap().0.header.sequence_number, 2);
 
-        let long = JitterBuffer::new(Duration::from_millis(200));
+        let long = JitterBuffer::new(Duration::from_millis(200), Duration::from_millis(20));
         long.push(make_pkt(3));
         let pkt = long.pop();
         assert!(
@@ -208,12 +226,12 @@ mod tests {
             pkt.is_some(),
             "long depth should release packet after delay"
         );
-        assert_eq!(pkt.unwrap().header.sequence_number, 3);
+        assert_eq!(pkt.unwrap().0.header.sequence_number, 3);
     }
 
     #[test]
     fn sequence_wrap_around() {
-        let jb = JitterBuffer::new(Duration::from_millis(50));
+        let jb = JitterBuffer::new(Duration::from_millis(50), Duration::from_millis(20));
         jb.push(make_pkt(0));
         jb.push(make_pkt(65535));
         jb.push(make_pkt(65534));
@@ -229,7 +247,7 @@ mod tests {
 
     #[test]
     fn empty() {
-        let jb = JitterBuffer::new(Duration::from_millis(50));
+        let jb = JitterBuffer::new(Duration::from_millis(50), Duration::from_millis(20));
         let pkts = jb.flush();
         assert!(pkts.is_empty());
         let pkt = jb.pop();

--- a/src/media.rs
+++ b/src/media.rs
@@ -828,7 +828,8 @@ fn drain_jb_inline(
             if let Some(ref mut proc) = cp {
                 let empty = vec![0u8; 0];
                 for _ in 0..skipped {
-                    let _ = proc.decode(&empty);
+                    let pcm = proc.decode(&empty);
+                    send_drop_oldest(&channels.pcm_reader.tx, &channels.pcm_reader.rx, pcm);
                 }
                 let pcm = proc.decode(&pkt.payload);
                 send_drop_oldest(&channels.pcm_reader.tx, &channels.pcm_reader.rx, pcm);

--- a/src/media.rs
+++ b/src/media.rs
@@ -518,7 +518,7 @@ pub fn start_media(
         let mut last_dtmf_seen = false;
 
         let mut last_rtp_time = Instant::now();
-        let jitter_tick = crossbeam_channel::tick(Duration::from_millis(5));
+        let jitter_tick = crossbeam_channel::tick(jitter_frame);
 
         // Paced outbound PCM state. Uses VecDeque for O(1) drain from front.
         let frame_size = (pcm_rate / 50) as usize; // 160 samples for 8kHz (20ms frame)

--- a/src/media.rs
+++ b/src/media.rs
@@ -22,6 +22,8 @@ use crate::types::*;
 /// Default media configuration values.
 const DEFAULT_MEDIA_TIMEOUT: Duration = Duration::from_secs(30);
 const DEFAULT_JITTER_DEPTH: Duration = Duration::from_millis(50);
+// To avoid problems, choose the shortest frame size for this value.
+const DEFAULT_JITTER_FRAME: Duration = Duration::from_millis(5);
 const DEFAULT_PCM_RATE: i32 = 8000;
 const CHANNEL_CAPACITY: usize = 256;
 
@@ -51,6 +53,8 @@ pub struct MediaConfig {
     pub media_timeout: Duration,
     /// Playout delay for the jitter buffer.
     pub jitter_depth: Duration,
+    /// Playout delay for each packet in the jitter buffer.
+    pub jitter_frame: Duration,
     /// PCM sample rate in Hz (typically 8000).
     pub pcm_rate: i32,
     /// Audio codec to use for encoding/decoding.
@@ -75,6 +79,7 @@ impl Default for MediaConfig {
         Self {
             media_timeout: DEFAULT_MEDIA_TIMEOUT,
             jitter_depth: DEFAULT_JITTER_DEPTH,
+            jitter_frame: DEFAULT_JITTER_FRAME,
             pcm_rate: DEFAULT_PCM_RATE,
             codec: Codec::PCMU,
             srtp_inbound: None,
@@ -360,6 +365,11 @@ pub fn start_media(
     } else {
         config.jitter_depth
     };
+    let jitter_frame = if config.jitter_frame == Duration::ZERO {
+        DEFAULT_JITTER_FRAME
+    } else {
+        config.jitter_frame
+    };
     let pcm_rate = if config.pcm_rate == 0 {
         DEFAULT_PCM_RATE
     } else {
@@ -498,7 +508,7 @@ pub fn start_media(
     let channels_for_thread = Arc::clone(&channels);
     let thread = std::thread::spawn(move || {
         let channels = channels_for_thread;
-        let mut jb = JitterBuffer::new(jitter_depth);
+        let mut jb = JitterBuffer::new(jitter_depth, jitter_frame);
         let mut out_seq: u16 = 0;
         let mut out_timestamp: u32 = 0;
         let out_ssrc = rand_u32();
@@ -575,9 +585,7 @@ pub fn start_media(
                     rtcp_stats.record_rtp_received(&pkt, pcm_rate as u32);
                     jb.push(pkt);
                     last_rtp_time = Instant::now();
-                    drain_jb_inline(&mut jb, &mut cp, &channels);
                 },
-
                 recv(jitter_tick) -> _ => {
                     drain_jb_inline(&mut jb, &mut cp, &channels);
 
@@ -807,7 +815,7 @@ fn drain_jb_inline(
     channels: &MediaChannels,
 ) {
     loop {
-        let pkt = match jb.pop() {
+        let (pkt, skipped) = match jb.pop() {
             Some(p) => p,
             None => return,
         };
@@ -818,6 +826,10 @@ fn drain_jb_inline(
         );
         if !pkt.payload.is_empty() {
             if let Some(ref mut proc) = cp {
+                let empty = vec![0u8; 0];
+                for _ in 0..skipped {
+                    let _ = proc.decode(&empty);
+                }
                 let pcm = proc.decode(&pkt.payload);
                 send_drop_oldest(&channels.pcm_reader.tx, &channels.pcm_reader.rx, pcm);
             }

--- a/src/sdp.rs
+++ b/src/sdp.rs
@@ -144,7 +144,7 @@ fn codec_fmtp(pt: i32) -> Option<&'static str> {
     match pt {
         18 => Some("annexb=no"),
         101 => Some("0-16"),
-        111 => Some("minptime=20;useinbandfec=0"),
+        111 => Some("minptime=20;useinbandfec=1;maxplaybackrate=8000"),
         _ => None,
     }
 }


### PR DESCRIPTION
Summary
---

Use BTreeMap for jitter buffer instead of vector buffer and seen buffer.
Allow flexible packet pop for jitter buffer by using estmated frame rate.
Implement forward error correction for Opus.

Tests
---
Passed jitter::tests and codec::opus_codec::tests.