### PR TITLE
SIP INVITE error

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -26,6 +26,9 @@ pub enum Error {
     /// `code == 0`.
     #[error("{}", format_registration_failed(*code, reason))]
     RegistrationFailed { code: u16, reason: String },
+    /// SIP INVITE was rejected or failed.
+    #[error("xphone: invite error occurs {code} {reason}")]
+    InviteFailed { code: u16, reason: String },
     /// SIP REFER (blind transfer) was rejected or failed.
     #[error("xphone: transfer failed")]
     TransferFailed,

--- a/src/sip/client.rs
+++ b/src/sip/client.rs
@@ -542,10 +542,10 @@ impl Client {
             Ok(ConsumeResult::Redirect(new_target))
         } else {
             self.tm.remove_tx(branch);
-            Err(Error::Other(format!(
-                "sip: INVITE rejected: {} {}",
-                resp.status_code, resp.reason
-            )))
+            Err(Error::InviteFailed {
+                code: resp.status_code,
+                reason: resp.reason,
+            })
         }
     }
 


### PR DESCRIPTION
Summary
---
Create a new error object InviteFailed (in the case sip invite was rejected or failed as of RegistrationFailed).

Breaking Changes
---
The sip::Client may return InviteFailed instead of Other.
